### PR TITLE
Enable the client to configure from a connection URI - fixes #40

### DIFF
--- a/src/main/docs/index.md
+++ b/src/main/docs/index.md
@@ -61,6 +61,12 @@ The following parameters are supported:
 * `PGUSER`
 * `PGPASSWORD`
 
+We also provide you an alternative way to connect when you want to configure with a connection URI:
+
+```$lang
+{@link examples.Examples#connectingWithUri}
+```
+
 ## Connecting to Postgres
 
 Most of the time you will use a pool to connect to Postgres:

--- a/src/main/docs/index.md
+++ b/src/main/docs/index.md
@@ -67,6 +67,8 @@ We also provide you an alternative way to connect when you want to configure wit
 {@link examples.Examples#connectingWithUri}
 ```
 
+More information about connection string formats can be found in the [PostgreSQL Manuals](https://www.postgresql.org/docs/9.6/static/libpq-connect.html#LIBPQ-CONNSTRING).
+
 ## Connecting to Postgres
 
 Most of the time you will use a pool to connect to Postgres:

--- a/src/main/docs/index.md
+++ b/src/main/docs/index.md
@@ -64,7 +64,7 @@ The following parameters are supported:
 We also provide you an alternative way to connect when you want to configure with a connection URI:
 
 ```$lang
-{@link examples.Examples#connectingWithUri}
+{@link examples.Examples#configureFromUri}
 ```
 
 More information about connection string formats can be found in the [PostgreSQL Manuals](https://www.postgresql.org/docs/9.6/static/libpq-connect.html#LIBPQ-CONNSTRING).

--- a/src/main/java/examples/Examples.java
+++ b/src/main/java/examples/Examples.java
@@ -62,6 +62,15 @@ public class Examples {
     });
   }
 
+  public void connectingWithUri() {
+
+    // Connection URI
+    String connectionUri = "postgresql://dbuser:secretpassword@database.server.com:3211/mydb";
+
+    // Create the pooled client
+    PgPool client = PgClient.pool(connectionUri);
+  }
+
   public void connecting01() {
 
     // Pool options

--- a/src/main/java/examples/Examples.java
+++ b/src/main/java/examples/Examples.java
@@ -62,13 +62,13 @@ public class Examples {
     });
   }
 
-  public void connectingWithUri() {
+  public void configureFromUri() {
 
     // Connection URI
     String connectionUri = "postgresql://dbuser:secretpassword@database.server.com:3211/mydb";
 
-    // Create the pooled client
-    PgPool client = PgClient.pool(connectionUri);
+    // Create the PgConnectOptions from the connection URI
+    PgConnectOptions pgConnectOptions = PgConnectOptionsProvider.fromUri(connectionUri);
   }
 
   public void connecting01() {

--- a/src/main/java/io/reactiverse/pgclient/PgClient.java
+++ b/src/main/java/io/reactiverse/pgclient/PgClient.java
@@ -27,8 +27,6 @@ import io.vertx.core.*;
 
 import java.util.List;
 
-import static io.reactiverse.pgclient.PgConnectOptionsProvider.*;
-
 /**
  * Defines the client operations with a Postgres Database.
  *
@@ -86,13 +84,6 @@ public interface PgClient {
         connect(vertx, options, handler);
       });
     }
-  }
-
-  /**
-   * Like {@link #connect(Vertx, PgConnectOptions, Handler)} but with a specific connection URI to configure the connection.
-   */
-  static void connect(Vertx vertx, String connectionUri, Handler<AsyncResult<PgConnection>> handler) {
-    connect(vertx, fromUri(connectionUri), handler);
   }
 
   /**

--- a/src/main/java/io/reactiverse/pgclient/PgClient.java
+++ b/src/main/java/io/reactiverse/pgclient/PgClient.java
@@ -58,23 +58,6 @@ public interface PgClient {
   }
 
   /**
-   * Create a connection pool to the database configured with the given {@code connectionUri}.
-   *
-   * @param connectionUri the connection URI
-   * @return the connection pool
-   */
-  static PgPool pool(String connectionUri) {
-    return PgClient.pool((PgPoolOptions) fromUri(connectionUri));
-  }
-
-  /**
-   * Like {@link #pool(String)} with a specific {@link Vertx} instance.
-   */
-  static PgPool pool(Vertx vertx, String connectionUri) {
-    return PgClient.pool(vertx, (PgPoolOptions) fromUri(connectionUri));
-  }
-
-  /**
    * Connects to the database and returns the connection if that succeeds.
    * <p/>
    * The connection interracts directly with the database is not a proxy, so closing the
@@ -106,7 +89,7 @@ public interface PgClient {
   }
 
   /**
-   * Like {@link #connect(Vertx, PgConnectOptions, Handler)} with a specific connection URI to configure the connection.
+   * Like {@link #connect(Vertx, PgConnectOptions, Handler)} but with a specific connection URI to configure the connection.
    */
   static void connect(Vertx vertx, String connectionUri, Handler<AsyncResult<PgConnection>> handler) {
     connect(vertx, fromUri(connectionUri), handler);

--- a/src/main/java/io/reactiverse/pgclient/PgClient.java
+++ b/src/main/java/io/reactiverse/pgclient/PgClient.java
@@ -27,6 +27,8 @@ import io.vertx.core.*;
 
 import java.util.List;
 
+import static io.reactiverse.pgclient.impl.PgConnectionUriParser.*;
+
 /**
  * Defines the client operations with a Postgres Database.
  *
@@ -53,6 +55,23 @@ public interface PgClient {
    */
   static PgPool pool(Vertx vertx, PgPoolOptions options) {
     return new PgPoolImpl(vertx, false, options);
+  }
+
+  /**
+   * Create a connection pool to the database configured with the given {@code connectionUri}.
+   *
+   * @param connectionUri the connection URI
+   * @return the connection pool
+   */
+  static PgPool pool(String connectionUri) {
+    return PgClient.pool(translateToPgPoolOptions(connectionUri));
+  }
+
+  /**
+   * Like {@link #pool(String)} with a specific {@link Vertx} instance.
+   */
+  static PgPool pool(Vertx vertx, String connectionUri) {
+    return PgClient.pool(vertx, translateToPgPoolOptions(connectionUri));
   }
 
   /**
@@ -84,6 +103,13 @@ public interface PgClient {
         connect(vertx, options, handler);
       });
     }
+  }
+
+  /**
+   * Like {@link #connect(Vertx, PgConnectOptions, Handler)} with a specific connection URI to configure the connection.
+   */
+  static void connect(Vertx vertx, String connectionUri, Handler<AsyncResult<PgConnection>> handler) {
+    connect(vertx, translateToPgConnectOptions(connectionUri), handler);
   }
 
   /**

--- a/src/main/java/io/reactiverse/pgclient/PgClient.java
+++ b/src/main/java/io/reactiverse/pgclient/PgClient.java
@@ -27,7 +27,7 @@ import io.vertx.core.*;
 
 import java.util.List;
 
-import static io.reactiverse.pgclient.impl.PgConnectionUriParser.*;
+import static io.reactiverse.pgclient.PgConnectOptionsProvider.*;
 
 /**
  * Defines the client operations with a Postgres Database.
@@ -64,14 +64,14 @@ public interface PgClient {
    * @return the connection pool
    */
   static PgPool pool(String connectionUri) {
-    return PgClient.pool(translateToPgPoolOptions(connectionUri));
+    return PgClient.pool((PgPoolOptions) fromUri(connectionUri));
   }
 
   /**
    * Like {@link #pool(String)} with a specific {@link Vertx} instance.
    */
   static PgPool pool(Vertx vertx, String connectionUri) {
-    return PgClient.pool(vertx, translateToPgPoolOptions(connectionUri));
+    return PgClient.pool(vertx, (PgPoolOptions) fromUri(connectionUri));
   }
 
   /**
@@ -109,7 +109,7 @@ public interface PgClient {
    * Like {@link #connect(Vertx, PgConnectOptions, Handler)} with a specific connection URI to configure the connection.
    */
   static void connect(Vertx vertx, String connectionUri, Handler<AsyncResult<PgConnection>> handler) {
-    connect(vertx, translateToPgConnectOptions(connectionUri), handler);
+    connect(vertx, fromUri(connectionUri), handler);
   }
 
   /**

--- a/src/main/java/io/reactiverse/pgclient/PgConnectOptions.java
+++ b/src/main/java/io/reactiverse/pgclient/PgConnectOptions.java
@@ -374,6 +374,13 @@ public class PgConnectOptions extends NetClientOptions {
   }
 
   @Override
+  public JsonObject toJson() {
+    JsonObject json = super.toJson();
+    PgConnectOptionsConverter.toJson(this, json);
+    return json;
+  }
+
+  @Override
   public boolean equals(Object o) {
     if (this == o) return true;
     if (!(o instanceof PgConnectOptions)) return false;

--- a/src/main/java/io/reactiverse/pgclient/PgConnectOptions.java
+++ b/src/main/java/io/reactiverse/pgclient/PgConnectOptions.java
@@ -24,9 +24,6 @@ import io.vertx.core.net.*;
 
 import java.util.Set;
 
-import static java.lang.Integer.*;
-import static java.lang.System.*;
-
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
@@ -337,7 +334,7 @@ public class PgConnectOptions extends NetClientOptions {
   }
 
   /**
-   * Initialize with the default options, if env variables are specified they take precedence over these options.
+   * Initialize with the default options.
    */
   private void init() {
     host = DEFAULT_HOST;
@@ -347,30 +344,6 @@ public class PgConnectOptions extends NetClientOptions {
     password = DEFAULT_PASSWORD;
     cachePreparedStatements = DEFAULT_CACHE_PREPARED_STATEMENTS;
     pipeliningLimit = DEFAULT_PIPELINING_LIMIT;
-
-    if (getenv("PGHOSTADDR") == null) {
-      if (getenv("PGHOST") != null) {
-        host = getenv("PGHOST");
-      }
-    } else {
-      host = getenv("PGHOSTADDR");
-    }
-    if (getenv("PGPORT") != null) {
-      try {
-        port = parseInt(getenv("PGPORT"));
-      } catch (NumberFormatException e) {
-        // port will be set to default
-      }
-    }
-    if (getenv("PGDATABASE") != null) {
-      database = getenv("PGDATABASE");
-    }
-    if (getenv("PGUSER") != null) {
-      username = getenv("PGUSER");
-    }
-    if (getenv("PGPASSWORD") != null) {
-      password = getenv("PGPASSWORD");
-    }
   }
 
   @Override

--- a/src/main/java/io/reactiverse/pgclient/PgConnectOptions.java
+++ b/src/main/java/io/reactiverse/pgclient/PgConnectOptions.java
@@ -372,4 +372,36 @@ public class PgConnectOptions extends NetClientOptions {
       password = getenv("PGPASSWORD");
     }
   }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof PgConnectOptions)) return false;
+    if (!super.equals(o)) return false;
+
+    PgConnectOptions that = (PgConnectOptions) o;
+
+    if (!host.equals(that.host)) return false;
+    if (port != that.port) return false;
+    if (!database.equals(that.database)) return false;
+    if (!username.equals(that.username)) return false;
+    if (!password.equals(that.password)) return false;
+    if (cachePreparedStatements != that.cachePreparedStatements) return false;
+    if (pipeliningLimit != that.pipeliningLimit) return false;
+
+    return true;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = super.hashCode();
+    result = 31 * result + host.hashCode();
+    result = 31 * result + port;
+    result = 31 * result + database.hashCode();
+    result = 31 * result + username.hashCode();
+    result = 31 * result + password.hashCode();
+    result = 31 * result + (cachePreparedStatements ? 1 : 0);
+    result = 31 * result + pipeliningLimit;
+    return result;
+  }
 }

--- a/src/main/java/io/reactiverse/pgclient/PgConnectOptionsProvider.java
+++ b/src/main/java/io/reactiverse/pgclient/PgConnectOptionsProvider.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2017 Julien Viet
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 package io.reactiverse.pgclient;
 
 import io.reactiverse.pgclient.impl.PgConnectionUriParser;

--- a/src/main/java/io/reactiverse/pgclient/PgConnectOptionsProvider.java
+++ b/src/main/java/io/reactiverse/pgclient/PgConnectOptionsProvider.java
@@ -4,6 +4,9 @@ import io.reactiverse.pgclient.impl.PgConnectionUriParser;
 import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.json.JsonObject;
 
+import static java.lang.Integer.parseInt;
+import static java.lang.System.getenv;
+
 /**
  * @author Billy Yuan <billy112487983@gmail.com>
  */
@@ -19,5 +22,39 @@ public interface PgConnectOptionsProvider {
     } else {
       return new PgConnectOptions(parsedConfiguration);
     }
+  }
+
+  /**
+   * Provide an {@link PgConnectOptions} configured with environment variables.
+   */
+  static PgConnectOptions fromEnv() {
+    PgConnectOptions pgConnectOptions = new PgConnectOptions();
+
+    if (getenv("PGHOSTADDR") == null) {
+      if (getenv("PGHOST") != null) {
+        pgConnectOptions.setHost(getenv("PGHOST"));
+      }
+    } else {
+      pgConnectOptions.setHost(getenv("PGHOSTADDR"));
+    }
+
+    if (getenv("PGPORT") != null) {
+      try {
+        pgConnectOptions.setPort(parseInt(getenv("PGPORT")));
+      } catch (NumberFormatException e) {
+        // port will be set to default
+      }
+    }
+
+    if (getenv("PGDATABASE") != null) {
+      pgConnectOptions.setDatabase(getenv("PGDATABASE"));
+    }
+    if (getenv("PGUSER") != null) {
+      pgConnectOptions.setUsername(getenv("PGUSER"));
+    }
+    if (getenv("PGPASSWORD") != null) {
+      pgConnectOptions.setPassword(getenv("PGPASSWORD"));
+    }
+    return pgConnectOptions;
   }
 }

--- a/src/main/java/io/reactiverse/pgclient/PgConnectOptionsProvider.java
+++ b/src/main/java/io/reactiverse/pgclient/PgConnectOptionsProvider.java
@@ -29,7 +29,7 @@ import static java.lang.System.getenv;
 @VertxGen
 public interface PgConnectOptionsProvider {
   /**
-   * Provide an {@link PgConnectOptions} configured with a connection URI.
+   * Provide a {@link PgConnectOptions} configured from a connection URI.
    */
   static PgConnectOptions fromUri(String connectionUri) {
     JsonObject parsedConfiguration = PgConnectionUriParser.parse(connectionUri);
@@ -41,7 +41,8 @@ public interface PgConnectOptionsProvider {
   }
 
   /**
-   * Provide an {@link PgConnectOptions} configured with environment variables.
+   * Provide a {@link PgConnectOptions} configured with environment variables, if the environment variable
+   * is not set, then a default value will take precedence over this.
    */
   static PgConnectOptions fromEnv() {
     PgConnectOptions pgConnectOptions = new PgConnectOptions();

--- a/src/main/java/io/reactiverse/pgclient/PgConnectOptionsProvider.java
+++ b/src/main/java/io/reactiverse/pgclient/PgConnectOptionsProvider.java
@@ -1,0 +1,23 @@
+package io.reactiverse.pgclient;
+
+import io.reactiverse.pgclient.impl.PgConnectionUriParser;
+import io.vertx.codegen.annotations.VertxGen;
+import io.vertx.core.json.JsonObject;
+
+/**
+ * @author Billy Yuan <billy112487983@gmail.com>
+ */
+@VertxGen
+public interface PgConnectOptionsProvider {
+  /**
+   * Provide an {@link PgConnectOptions} configured with a connection URI.
+   */
+  static PgConnectOptions fromUri(String connectionUri) {
+    JsonObject parsedConfiguration = PgConnectionUriParser.parse(connectionUri);
+    if (parsedConfiguration == null) {
+      return new PgConnectOptions();
+    } else {
+      return new PgConnectOptions(parsedConfiguration);
+    }
+  }
+}

--- a/src/main/java/io/reactiverse/pgclient/PgConnectOptionsProvider.java
+++ b/src/main/java/io/reactiverse/pgclient/PgConnectOptionsProvider.java
@@ -30,14 +30,14 @@ import static java.lang.System.getenv;
 public interface PgConnectOptionsProvider {
   /**
    * Provide a {@link PgConnectOptions} configured from a connection URI.
+   *
+   * @param connectionUri the connection URI to configure from
+   * @return a {@code PgConnectOptions} parsed from the connection URI
+   * @throws IllegalArgumentException when the {@code connectionUri} is in an invalid format
    */
-  static PgConnectOptions fromUri(String connectionUri) {
+  static PgConnectOptions fromUri(String connectionUri) throws IllegalArgumentException {
     JsonObject parsedConfiguration = PgConnectionUriParser.parse(connectionUri);
-    if (parsedConfiguration == null) {
-      return new PgConnectOptions();
-    } else {
-      return new PgConnectOptions(parsedConfiguration);
-    }
+    return new PgConnectOptions(parsedConfiguration);
   }
 
   /**

--- a/src/main/java/io/reactiverse/pgclient/PgPoolOptions.java
+++ b/src/main/java/io/reactiverse/pgclient/PgPoolOptions.java
@@ -300,4 +300,24 @@ public class PgPoolOptions extends PgConnectOptions {
     PgPoolOptionsConverter.toJson(this, json);
     return json;
   }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof PgPoolOptions)) return false;
+    if (!super.equals(o)) return false;
+
+    PgPoolOptions that = (PgPoolOptions) o;
+
+    if (maxSize != that.maxSize) return false;
+
+    return true;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = super.hashCode();
+    result = 31 * result + maxSize;
+    return result;
+  }
 }

--- a/src/main/java/io/reactiverse/pgclient/impl/PgConnectionUriParser.java
+++ b/src/main/java/io/reactiverse/pgclient/impl/PgConnectionUriParser.java
@@ -1,7 +1,5 @@
 package io.reactiverse.pgclient.impl;
 
-import io.reactiverse.pgclient.PgConnectOptions;
-import io.reactiverse.pgclient.PgPoolOptions;
 import io.vertx.core.json.JsonObject;
 
 import java.io.UnsupportedEncodingException;
@@ -27,7 +25,7 @@ public class PgConnectionUriParser {
   private static final int DATABASE_GROUP = 4;
   private static final int PARAMETER_GROUP = 5;
 
-  private static JsonObject parse(String connectionUri) {
+  public static JsonObject parse(String connectionUri) {
     // if we get any exception during the parsing, then we return a null.
     try {
       JsonObject configuration = new JsonObject();
@@ -35,24 +33,6 @@ public class PgConnectionUriParser {
       return configuration;
     } catch (Exception e) {
       return null;
-    }
-  }
-
-  public static PgPoolOptions translateToPgPoolOptions(String connectionUri) {
-    JsonObject parsedConfiguration = parse(connectionUri);
-    if (parsedConfiguration == null) {
-      return new PgPoolOptions();
-    } else {
-      return new PgPoolOptions(parsedConfiguration);
-    }
-  }
-
-  public static PgConnectOptions translateToPgConnectOptions(String connectionUri) {
-    JsonObject parsedConfiguration = parse(connectionUri);
-    if (parsedConfiguration == null) {
-      return new PgConnectOptions();
-    } else {
-      return new PgConnectOptions(parsedConfiguration);
     }
   }
 

--- a/src/main/java/io/reactiverse/pgclient/impl/PgConnectionUriParser.java
+++ b/src/main/java/io/reactiverse/pgclient/impl/PgConnectionUriParser.java
@@ -1,0 +1,221 @@
+package io.reactiverse.pgclient.impl;
+
+import io.reactiverse.pgclient.PgConnectOptions;
+import io.reactiverse.pgclient.PgPoolOptions;
+import io.vertx.core.json.JsonObject;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static java.lang.Integer.*;
+import static java.lang.String.*;
+
+/**
+ * This is Parser for parsing connection URIs of PostgreSQL.
+ * Based on Version 9.6
+ *
+ * @author Billy Yuan <billy112487983@gmail.com>
+ */
+public class PgConnectionUriParser {
+  private static final String FULL_URI_REGEX = "^postgre(?:s|sql)://(?:(\\w+(?::\\S+)?)@)?([0-9.]+|\\[[A-Za-z0-9:]+]|[A-Za-z0-9.%\\-_]+)?(?::(\\d+))?(?:/([A-Za-z0-9_\\-]+))?(?:\\?(.*))?$";
+
+  private static int USER_INFO_GROUP = 1;
+  private static int NET_LOCATION_GROUP = 2;
+  private static int PORT_GROUP = 3;
+  private static int DATABASE_GROUP = 4;
+  private static int PARAMETER_GROUP = 5;
+
+  private final String connectionUri;
+
+  private JsonObject configuration = new JsonObject();
+
+  private PgConnectionUriParser(String connectionUri) {
+    this.connectionUri = connectionUri;
+    doParse();
+  }
+
+  private static JsonObject parse(String connectionUri) {
+    // if we get any exception during the parsing, then we return a null.
+    try {
+      PgConnectionUriParser pgConnectionUriParser = new PgConnectionUriParser(connectionUri);
+      return pgConnectionUriParser.getConfiguration();
+    } catch (Exception e) {
+      return null;
+    }
+  }
+
+  public static PgPoolOptions translateToPgPoolOptions(String connectionUri) {
+    JsonObject parsedConfiguration = parse(connectionUri);
+    if (parsedConfiguration == null) {
+      return new PgPoolOptions();
+    } else {
+      return new PgPoolOptions(parsedConfiguration);
+    }
+  }
+
+  public static PgConnectOptions translateToPgConnectOptions(String connectionUri) {
+    JsonObject parsedConfiguration = parse(connectionUri);
+    if (parsedConfiguration == null) {
+      return new PgConnectOptions();
+    } else {
+      return new PgConnectOptions(parsedConfiguration);
+    }
+  }
+
+  private JsonObject getConfiguration() {
+    return configuration;
+  }
+
+  public String getConnectionUri() {
+    return connectionUri;
+  }
+
+  private void doParse() {
+    Pattern pattern = Pattern.compile(FULL_URI_REGEX);
+    Matcher matcher = pattern.matcher(connectionUri);
+
+    if (matcher.matches()) {
+      // parse the username and password
+      parseUsernameAndPassword(matcher.group(USER_INFO_GROUP));
+
+      // parse the IP address/host/unix domainSocket address
+      parseNetLocation(matcher.group(NET_LOCATION_GROUP));
+
+      // parse the port
+      parsePort(matcher.group(PORT_GROUP));
+
+      // parse the database name
+      parseDatabaseName(matcher.group(DATABASE_GROUP));
+
+      // parse the parameters
+      parseParameters(matcher.group(PARAMETER_GROUP));
+
+    } else {
+      throw new IllegalArgumentException("Wrong syntax of connection URI");
+    }
+  }
+
+  private void parseUsernameAndPassword(String userInfo) {
+    if (userInfo == null || userInfo.isEmpty()) {
+      return;
+    }
+    if (occurExactlyOnce(userInfo, ":")) {
+      int index = userInfo.indexOf(":");
+      String username = userInfo.substring(0, index);
+      if (username.isEmpty()) {
+        throw new IllegalArgumentException("Can not only specify the password without a concrete username");
+      }
+      String password = userInfo.substring(index + 1);
+      configuration.put("username", decodeUrl(username));
+      configuration.put("password", decodeUrl(password));
+    } else if (!userInfo.contains(":")) {
+      configuration.put("username", decodeUrl(userInfo));
+    } else {
+      throw new IllegalArgumentException("Can not use multiple delimiters to delimit username and password");
+    }
+  }
+
+  private void parseNetLocation(String hostInfo) {
+    if (hostInfo == null || hostInfo.isEmpty()) {
+      return;
+    }
+    parseNetLocationValue(decodeUrl(hostInfo));
+  }
+
+  private void parsePort(String portInfo) {
+    if (portInfo == null || portInfo.isEmpty()) {
+      return;
+    }
+    int port;
+    try {
+      port = parseInt(decodeUrl(portInfo));
+    } catch (NumberFormatException e) {
+      throw new IllegalArgumentException("The post must be a valid integer");
+    }
+    if (port > 65535 || port <= 0) {
+      throw new IllegalArgumentException("The post can only range in 1-65535");
+    }
+    configuration.put("port", port);
+  }
+
+  private void parseDatabaseName(String databaseInfo) {
+    if (databaseInfo == null || databaseInfo.isEmpty()) {
+      return;
+    }
+    configuration.put("database", decodeUrl(databaseInfo));
+
+  }
+
+  private void parseParameters(String parametersInfo) {
+    if (parametersInfo == null || parametersInfo.isEmpty()) {
+      return;
+    }
+    for (String parameterPair : parametersInfo.split("&")) {
+      if (parameterPair.isEmpty()) {
+        continue;
+      }
+      int indexOfDelimiter = parameterPair.indexOf("=");
+      if (indexOfDelimiter < 0) {
+        throw new IllegalArgumentException(format("Missing delimiter '=' of parameters \"%s\" in the part \"%s\"", parametersInfo, parameterPair));
+      } else {
+        String key = parameterPair.substring(0, indexOfDelimiter).toLowerCase();
+        String value = decodeUrl(parameterPair.substring(indexOfDelimiter + 1).trim());
+        switch (key) {
+          case "port":
+            parsePort(value);
+            break;
+          case "host":
+            parseNetLocationValue(value);
+            break;
+          case "hostaddr":
+            configuration.put("host", value);
+            break;
+          case "user":
+            configuration.put("username", value);
+            break;
+          case "password":
+            configuration.put("password", value);
+            break;
+          case "dbname":
+            configuration.put("database", value);
+            break;
+          default:
+            configuration.put(key, value);
+            break;
+        }
+      }
+    }
+  }
+
+  private void parseNetLocationValue(String hostValue) {
+    if (isRegardedAsDomainSocketAddress(hostValue)) {
+      configuration.put("domainsocket", hostValue);
+    } else if (isRegardedAsIpv6Address(hostValue)) {
+      configuration.put("host", hostValue.substring(1, hostValue.length() - 1));
+    } else {
+      configuration.put("host", hostValue);
+    }
+  }
+
+  private boolean isRegardedAsIpv6Address(String hostAddress) {
+    return hostAddress.startsWith("[") && hostAddress.endsWith("]");
+  }
+
+  private boolean isRegardedAsDomainSocketAddress(String hostAddress) {
+    return hostAddress.startsWith("/") || hostAddress.startsWith("%2F");
+  }
+
+  private String decodeUrl(String url) {
+    try {
+      return URLDecoder.decode(url, "UTF-8");
+    } catch (UnsupportedEncodingException e) {
+      throw new IllegalArgumentException("The connection uri contains unknown characters that can not be resolved.");
+    }
+  }
+
+  private boolean occurExactlyOnce(String uri, String character) {
+    return uri.contains(character) && uri.indexOf(character) == uri.lastIndexOf(character);
+  }
+}

--- a/src/main/java/io/reactiverse/pgclient/impl/PgConnectionUriParser.java
+++ b/src/main/java/io/reactiverse/pgclient/impl/PgConnectionUriParser.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2017 Julien Viet
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 package io.reactiverse.pgclient.impl;
 
 import io.vertx.core.json.JsonObject;

--- a/src/main/java/io/reactiverse/pgclient/impl/PgConnectionUriParser.java
+++ b/src/main/java/io/reactiverse/pgclient/impl/PgConnectionUriParser.java
@@ -48,7 +48,7 @@ public class PgConnectionUriParser {
       doParse(connectionUri, configuration);
       return configuration;
     } catch (Exception e) {
-      return null;
+      throw new IllegalArgumentException("Can not parse an invalid connection URI");
     }
   }
 

--- a/src/main/java/io/reactiverse/pgclient/package-info.java
+++ b/src/main/java/io/reactiverse/pgclient/package-info.java
@@ -85,7 +85,7 @@
  *
  * [source,$lang]
  * ----
- * {@link examples.Examples#connectingWithUri()}
+ * {@link examples.Examples#configureFromUri}
  * ----
  *
  * More information about connection string formats can be found in the https://www.postgresql.org/docs/9.6/static/libpq-connect.html#LIBPQ-CONNSTRING[PostgreSQL Manuals].

--- a/src/main/java/io/reactiverse/pgclient/package-info.java
+++ b/src/main/java/io/reactiverse/pgclient/package-info.java
@@ -81,6 +81,13 @@
  * * `PGUSER`
  * * `PGPASSWORD`
  *
+ * We also provide you an alternative when you want to configure with a connection uri:
+ *
+ * [source,$lang]
+ * ----
+ * {@link examples.Examples#connectingWithUri()}
+ * ----
+ * 
  * == Connecting to Postgres
  *
  * Most of the time you will use a pool to connect to Postgres:

--- a/src/main/java/io/reactiverse/pgclient/package-info.java
+++ b/src/main/java/io/reactiverse/pgclient/package-info.java
@@ -87,7 +87,9 @@
  * ----
  * {@link examples.Examples#connectingWithUri()}
  * ----
- * 
+ *
+ * More information about connection string formats can be found in the https://www.postgresql.org/docs/9.6/static/libpq-connect.html#LIBPQ-CONNSTRING[PostgreSQL Manuals].
+ *
  * == Connecting to Postgres
  *
  * Most of the time you will use a pool to connect to Postgres:

--- a/src/test/java/io/reactiverse/pgclient/PgConnectOptionsProviderTest.java
+++ b/src/test/java/io/reactiverse/pgclient/PgConnectOptionsProviderTest.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright (C) 2017 Julien Viet
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package io.reactiverse.pgclient;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ * @author Billy Yuan <billy112487983@gmail.com>
+ */
+public class PgConnectOptionsProviderTest {
+  private String connectionUri;
+  private PgConnectOptions expectedConfiguration;
+  private PgConnectOptions actualConfiguration;
+
+  @Test
+  public void testValidUri1() {
+    connectionUri = "postgresql://";
+    actualConfiguration = PgConnectOptionsProvider.fromUri(connectionUri);
+
+    expectedConfiguration = new PgConnectOptions();
+
+    assertEquals(expectedConfiguration, actualConfiguration);
+  }
+
+  @Test
+  public void testValidUri2() {
+    connectionUri = "postgresql://myhost";
+    actualConfiguration = PgConnectOptionsProvider.fromUri(connectionUri);
+
+    expectedConfiguration = new PgConnectOptions()
+      .setHost("myhost");
+
+    assertEquals(expectedConfiguration, actualConfiguration);
+  }
+
+  @Test
+  public void testValidUri3() {
+    connectionUri = "postgresql://myhost:5433";
+    actualConfiguration = PgConnectOptionsProvider.fromUri(connectionUri);
+
+    expectedConfiguration = new PgConnectOptions()
+      .setHost("myhost")
+      .setPort(5433);
+
+    assertEquals(expectedConfiguration, actualConfiguration);
+  }
+
+  @Test
+  public void testValidUri4() {
+    connectionUri = "postgresql://myhost/mydb";
+    actualConfiguration = PgConnectOptionsProvider.fromUri(connectionUri);
+
+    expectedConfiguration = new PgConnectOptions()
+      .setHost("myhost")
+      .setDatabase("mydb");
+
+    assertEquals(expectedConfiguration, actualConfiguration);
+  }
+
+  @Test
+  public void testValidUri5() {
+    connectionUri = "postgresql://user@myhost";
+    actualConfiguration = PgConnectOptionsProvider.fromUri(connectionUri);
+
+    expectedConfiguration = new PgConnectOptions()
+      .setUsername("user")
+      .setHost("myhost");
+
+    assertEquals(expectedConfiguration, actualConfiguration);
+  }
+
+  @Test
+  public void testValidUri6() {
+    connectionUri = "postgresql://user:secret@myhost";
+    actualConfiguration = PgConnectOptionsProvider.fromUri(connectionUri);
+
+    expectedConfiguration = new PgConnectOptions()
+      .setUsername("user")
+      .setPassword("secret")
+      .setHost("myhost");
+
+    assertEquals(expectedConfiguration, actualConfiguration);
+  }
+
+  @Test
+  public void testValidUri7() {
+    connectionUri = "postgresql://other@localhost/otherdb?port=5433&password=secret";
+    actualConfiguration = PgConnectOptionsProvider.fromUri(connectionUri);
+
+    expectedConfiguration = new PgConnectOptions()
+      .setUsername("other")
+      .setPassword("secret")
+      .setHost("localhost")
+      .setPort(5433)
+      .setDatabase("otherdb");
+
+    assertEquals(expectedConfiguration, actualConfiguration);
+  }
+
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testInvalidUri1() {
+    connectionUri = "postgrsql://username";
+    actualConfiguration = PgConnectOptionsProvider.fromUri(connectionUri);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testInvalidUri2() {
+    connectionUri = "postgresql://username:password@loc//dbname";
+    actualConfiguration = PgConnectOptionsProvider.fromUri(connectionUri);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testInvalidUri3() {
+    connectionUri = "postgresql://user@:passowrd@localhost/dbname/qwer";
+    actualConfiguration = PgConnectOptionsProvider.fromUri(connectionUri);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testInvalidUri4() {
+    connectionUri = "postgresql://user:password@localhost:655355/dbname";
+    actualConfiguration = PgConnectOptionsProvider.fromUri(connectionUri);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testInvalidUri5() {
+    connectionUri = "postgresql://user@localhost?port=1234&port";
+    actualConfiguration = PgConnectOptionsProvider.fromUri(connectionUri);
+  }
+}

--- a/src/test/java/io/reactiverse/pgclient/PgConnectionUriParserTest.java
+++ b/src/test/java/io/reactiverse/pgclient/PgConnectionUriParserTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2017 Julien Viet
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 package io.reactiverse.pgclient;
 
 import org.junit.Test;

--- a/src/test/java/io/reactiverse/pgclient/PgConnectionUriParserTest.java
+++ b/src/test/java/io/reactiverse/pgclient/PgConnectionUriParserTest.java
@@ -1,0 +1,387 @@
+package io.reactiverse.pgclient;
+
+import io.reactiverse.pgclient.impl.PgConnectionUriParser;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import static io.reactiverse.pgclient.impl.PgConnectionUriParser.*;
+import static org.junit.Assert.*;
+
+/**
+ * @author Billy Yuan <billy112487983@gmail.com>
+ */
+public class PgConnectionUriParserTest {
+  private String uri;
+  private PgPoolOptions actualParsedOptions;
+  private PgPoolOptions expectedParsedOptions;
+
+  @Test
+  public void testParsingUriSchemeDesignator() {
+    uri = "postgresql://";
+    actualParsedOptions = translateToPgPoolOptions(uri);
+
+    expectedParsedOptions = new PgPoolOptions();
+
+    assertEquals(expectedParsedOptions, actualParsedOptions);
+  }
+
+  @Test
+  public void testParsingAnotherUriSchemeDesignator() {
+    uri = "postgres://";
+    actualParsedOptions = translateToPgPoolOptions(uri);
+
+    expectedParsedOptions = new PgPoolOptions();
+
+    assertEquals(expectedParsedOptions, actualParsedOptions);
+
+  }
+
+  @Test
+  public void testParsingWrongUriSchemeDesignator() {
+    uri = "posttgres://localhost";
+    actualParsedOptions = translateToPgPoolOptions(uri);
+
+    expectedParsedOptions = new PgPoolOptions();
+
+    assertEquals(expectedParsedOptions, actualParsedOptions);
+  }
+
+  @Test
+  public void testParsingUsername() {
+    uri = "postgres://user@";
+    actualParsedOptions = translateToPgPoolOptions(uri);
+
+    expectedParsedOptions = new PgPoolOptions()
+      .setUsername("user");
+
+    assertEquals(expectedParsedOptions, actualParsedOptions);
+  }
+
+  @Test
+  public void testParsingPassword() {
+    uri = "postgresql://user:secret@localhost";
+    actualParsedOptions = translateToPgPoolOptions(uri);
+
+    expectedParsedOptions = new PgPoolOptions()
+      .setUsername("user")
+      .setPassword("secret")
+      .setHost("localhost");
+
+    assertEquals(expectedParsedOptions, actualParsedOptions);
+  }
+
+  @Test
+  public void testParsingHost() {
+    uri = "postgresql://localhost";
+    actualParsedOptions = translateToPgPoolOptions(uri);
+
+    expectedParsedOptions = new PgPoolOptions()
+      .setHost("localhost");
+
+    assertEquals(expectedParsedOptions, actualParsedOptions);
+  }
+
+  @Test
+  public void testParsingIpv4Address() {
+    uri = "postgresql://192.168.1.1:1234";
+    actualParsedOptions = translateToPgPoolOptions(uri);
+
+    expectedParsedOptions = new PgPoolOptions()
+      .setHost("192.168.1.1")
+      .setPort(1234);
+
+    assertEquals(expectedParsedOptions, actualParsedOptions);
+  }
+
+  @Test
+  public void testParsingIpv6Address() {
+    uri = "postgresql://[2001:db8::1234]/mydb";
+    actualParsedOptions = translateToPgPoolOptions(uri);
+
+    expectedParsedOptions = new PgPoolOptions()
+      .setHost("2001:db8::1234")
+      .setDatabase("mydb");
+
+    assertEquals(expectedParsedOptions, actualParsedOptions);
+  }
+
+  @Test
+  public void testParsingPort() {
+    uri = "postgresql://localhost:1234";
+    actualParsedOptions = translateToPgPoolOptions(uri);
+
+    expectedParsedOptions = new PgPoolOptions()
+      .setHost("localhost")
+      .setPort(1234);
+
+    assertEquals(expectedParsedOptions, actualParsedOptions);
+  }
+
+
+  @Test
+  public void testParsingDbName() {
+    uri = "postgres://localhost/mydb";
+    actualParsedOptions = translateToPgPoolOptions(uri);
+
+    expectedParsedOptions = new PgPoolOptions()
+      .setHost("localhost")
+      .setDatabase("mydb");
+
+    assertEquals(expectedParsedOptions, actualParsedOptions);
+  }
+
+
+  @Test
+  public void testParsingParameter() {
+    uri = "postgresql://localhost/otherdb?user=other";
+    actualParsedOptions = translateToPgPoolOptions(uri);
+
+    expectedParsedOptions = new PgPoolOptions()
+      .setUsername("other")
+      .setHost("localhost")
+      .setDatabase("otherdb");
+
+    assertEquals(expectedParsedOptions, actualParsedOptions);
+  }
+
+  @Test
+  public void testParsingParameters() {
+    uri = "postgresql://localhost/otherdb?user=other&password=secret&port=1234";
+    actualParsedOptions = translateToPgPoolOptions(uri);
+
+    expectedParsedOptions = new PgPoolOptions()
+      .setHost("localhost")
+      .setDatabase("otherdb")
+      .setUsername("other")
+      .setPassword("secret")
+      .setPort(1234);
+
+    assertEquals(expectedParsedOptions, actualParsedOptions);
+  }
+
+  @Test
+  public void testParsingHostAndParameters() {
+    uri = "postgresql://localhost?user=other&password=secret";
+    actualParsedOptions = translateToPgPoolOptions(uri);
+
+    expectedParsedOptions = new PgPoolOptions()
+      .setHost("localhost")
+      .setUsername("other")
+      .setPassword("secret");
+
+    assertEquals(expectedParsedOptions, actualParsedOptions);
+  }
+
+  @Test
+  public void testParsingUserWithoutPassword() {
+    uri = "postgresql://user@";
+    actualParsedOptions = translateToPgPoolOptions(uri);
+
+    expectedParsedOptions = new PgPoolOptions()
+      .setUsername("user");
+
+    assertEquals(expectedParsedOptions, actualParsedOptions);
+  }
+
+  @Test
+  public void testParsingPasswordWithoutUsername() {
+    uri = "postgresql://:secret@";
+    actualParsedOptions = translateToPgPoolOptions(uri);
+
+    expectedParsedOptions = new PgPoolOptions();
+
+    assertEquals(expectedParsedOptions, actualParsedOptions);
+  }
+
+  @Test
+  public void testParsingPortWithoutHost() {
+    // This URI is not valid in java.net.URI
+    uri = "postgresql://:1234";
+    actualParsedOptions = translateToPgPoolOptions(uri);
+
+    expectedParsedOptions = new PgPoolOptions()
+      .setPort(1234);
+
+    assertEquals(expectedParsedOptions, actualParsedOptions);
+  }
+
+  @Test
+  public void testParsingOnlyDbName() {
+    uri = "postgresql:///mydb";
+    actualParsedOptions = translateToPgPoolOptions(uri);
+
+    expectedParsedOptions = new PgPoolOptions()
+      .setDatabase("mydb");
+
+    assertEquals(expectedParsedOptions, actualParsedOptions);
+  }
+
+  @Test
+  public void testParsingOnlyParameters() {
+    uri = "postgresql://?host=localhost&port=1234";
+    actualParsedOptions = translateToPgPoolOptions(uri);
+
+    expectedParsedOptions = new PgPoolOptions()
+      .setHost("localhost")
+      .setPort(1234);
+
+    assertEquals(expectedParsedOptions, actualParsedOptions);
+  }
+
+  @Test
+  public void testParsingDomainSocket() {
+    uri = "postgresql://%2Fvar%2Flib%2Fpostgresql/dbname";
+    actualParsedOptions = translateToPgPoolOptions(uri);
+
+    expectedParsedOptions = new PgPoolOptions()
+      .setDatabase("dbname");
+
+    assertEquals(expectedParsedOptions, actualParsedOptions);
+  }
+
+  @Test
+  public void testParsingDomainSocketInParameter() {
+    uri = "postgresql:///dbname?host=/var/lib/postgresql";
+    actualParsedOptions = translateToPgPoolOptions(uri);
+
+    expectedParsedOptions = new PgPoolOptions()
+      .setDatabase("dbname");
+
+    assertEquals(expectedParsedOptions, actualParsedOptions);
+  }
+
+  @Test
+  public void testParsingInvalidUri() {
+    uri = "postgresql://@@/dbname?host";
+    actualParsedOptions = translateToPgPoolOptions(uri);
+
+    expectedParsedOptions = new PgPoolOptions();
+
+    assertEquals(expectedParsedOptions, actualParsedOptions);
+  }
+
+  @Test
+  public void testParsingUriWithOverridenParameters() {
+    uri = "postgresql://localhost/mydb?host=myhost&port=1234";
+    actualParsedOptions = translateToPgPoolOptions(uri);
+
+    expectedParsedOptions = new PgPoolOptions()
+      .setHost("myhost")
+      .setDatabase("mydb")
+      .setPort(1234);
+
+    assertEquals(expectedParsedOptions, actualParsedOptions);
+  }
+
+  @Test
+  public void testParsingFullUri() {
+    uri = "postgresql://dbuser:secretpassword@database.server.com:3211/mydb";
+    actualParsedOptions = translateToPgPoolOptions(uri);
+
+    expectedParsedOptions = new PgPoolOptions()
+      .setUsername("dbuser")
+      .setPassword("secretpassword")
+      .setHost("database.server.com")
+      .setPort(3211)
+      .setDatabase("mydb");
+
+    assertEquals(expectedParsedOptions, actualParsedOptions);
+
+    PgConnectOptions expectedPgConnectOptions = new PgConnectOptions()
+      .setUsername("dbuser")
+      .setPassword("secretpassword")
+      .setHost("database.server.com")
+      .setPort(3211)
+      .setDatabase("mydb");
+
+    PgConnectOptions actualPgConnectOptions = PgConnectionUriParser.translateToPgConnectOptions(uri);
+
+    assertEquals(expectedPgConnectOptions, actualPgConnectOptions);
+  }
+
+  @Test
+  public void testConvertingPgConnectOptions() {
+    uri = "postgresql://pg@localhost?password=secret123&port=1234";
+
+    PgConnectOptions expectedOptions = new PgConnectOptions()
+      .setUsername("pg")
+      .setPassword("secret123")
+      .setHost("localhost")
+      .setPort(1234);
+
+    assertEquals(expectedOptions, translateToPgConnectOptions(uri));
+  }
+
+  @Test
+  public void testConvertingWrongPgConnectOptions() {
+    uri = "postgresql://user:secret@localhost/mydb?port=1234";
+
+    PgConnectOptions wrongOptions = new PgConnectOptions()
+      .setUsername("pg")
+      .setPassword("secret123")
+      .setHost("localhost")
+      .setPort(1234);
+
+    assertNotEquals(wrongOptions, translateToPgConnectOptions(uri));
+  }
+
+  @Test
+  public void testInvalidUri1() {
+    uri = "postgresql://us@er@@";
+    actualParsedOptions = translateToPgPoolOptions(uri);
+
+    expectedParsedOptions = new PgPoolOptions();
+
+    assertEquals(expectedParsedOptions, actualParsedOptions);
+  }
+
+  @Test
+  public void testInvalidUri2() {
+    uri = "postgresql://user/mydb//";
+    actualParsedOptions = translateToPgPoolOptions(uri);
+
+    expectedParsedOptions = new PgPoolOptions();
+
+    assertEquals(expectedParsedOptions, actualParsedOptions);
+  }
+
+  @Test
+  public void testInvalidUri3() {
+    uri = "postgresql:///dbname/?host=localhost";
+    actualParsedOptions = translateToPgPoolOptions(uri);
+
+    expectedParsedOptions = new PgPoolOptions();
+
+    assertEquals(expectedParsedOptions, actualParsedOptions);
+  }
+
+  @Test
+  public void testInvalidUri4() {
+    uri = "postgresql://user::1234";
+    actualParsedOptions = translateToPgPoolOptions(uri);
+
+    expectedParsedOptions = new PgPoolOptions();
+
+    assertEquals(expectedParsedOptions, actualParsedOptions);
+  }
+
+  @Test
+  public void testInvalidUri5() {
+    uri = "postgresql://@:1234";
+    actualParsedOptions = translateToPgPoolOptions(uri);
+
+    expectedParsedOptions = new PgPoolOptions();
+
+    assertEquals(expectedParsedOptions, actualParsedOptions);
+  }
+
+  @Test
+  public void testInvalidUri6() {
+    uri = "postgresql://:123:";
+    actualParsedOptions = translateToPgPoolOptions(uri);
+
+    expectedParsedOptions = new PgPoolOptions();
+
+    assertEquals(expectedParsedOptions, actualParsedOptions);
+  }
+}

--- a/src/test/java/io/reactiverse/pgclient/PgConnectionUriParserTest.java
+++ b/src/test/java/io/reactiverse/pgclient/PgConnectionUriParserTest.java
@@ -1,10 +1,8 @@
 package io.reactiverse.pgclient;
 
-import io.reactiverse.pgclient.impl.PgConnectionUriParser;
-import org.junit.Ignore;
 import org.junit.Test;
 
-import static io.reactiverse.pgclient.impl.PgConnectionUriParser.*;
+import static io.reactiverse.pgclient.PgConnectOptionsProvider.*;
 import static org.junit.Assert.*;
 
 /**
@@ -12,15 +10,15 @@ import static org.junit.Assert.*;
  */
 public class PgConnectionUriParserTest {
   private String uri;
-  private PgPoolOptions actualParsedOptions;
-  private PgPoolOptions expectedParsedOptions;
+  private PgConnectOptions actualParsedOptions;
+  private PgConnectOptions expectedParsedOptions;
 
   @Test
   public void testParsingUriSchemeDesignator() {
     uri = "postgresql://";
-    actualParsedOptions = translateToPgPoolOptions(uri);
+    actualParsedOptions = fromUri(uri);
 
-    expectedParsedOptions = new PgPoolOptions();
+    expectedParsedOptions = new PgConnectOptions();
 
     assertEquals(expectedParsedOptions, actualParsedOptions);
   }
@@ -28,9 +26,9 @@ public class PgConnectionUriParserTest {
   @Test
   public void testParsingAnotherUriSchemeDesignator() {
     uri = "postgres://";
-    actualParsedOptions = translateToPgPoolOptions(uri);
+    actualParsedOptions = fromUri(uri);
 
-    expectedParsedOptions = new PgPoolOptions();
+    expectedParsedOptions = new PgConnectOptions();
 
     assertEquals(expectedParsedOptions, actualParsedOptions);
 
@@ -39,9 +37,9 @@ public class PgConnectionUriParserTest {
   @Test
   public void testParsingWrongUriSchemeDesignator() {
     uri = "posttgres://localhost";
-    actualParsedOptions = translateToPgPoolOptions(uri);
+    actualParsedOptions = fromUri(uri);
 
-    expectedParsedOptions = new PgPoolOptions();
+    expectedParsedOptions = new PgConnectOptions();
 
     assertEquals(expectedParsedOptions, actualParsedOptions);
   }
@@ -49,9 +47,9 @@ public class PgConnectionUriParserTest {
   @Test
   public void testParsingUsername() {
     uri = "postgres://user@";
-    actualParsedOptions = translateToPgPoolOptions(uri);
+    actualParsedOptions = fromUri(uri);
 
-    expectedParsedOptions = new PgPoolOptions()
+    expectedParsedOptions = new PgConnectOptions()
       .setUsername("user");
 
     assertEquals(expectedParsedOptions, actualParsedOptions);
@@ -60,9 +58,9 @@ public class PgConnectionUriParserTest {
   @Test
   public void testParsingPassword() {
     uri = "postgresql://user:secret@localhost";
-    actualParsedOptions = translateToPgPoolOptions(uri);
+    actualParsedOptions = fromUri(uri);
 
-    expectedParsedOptions = new PgPoolOptions()
+    expectedParsedOptions = new PgConnectOptions()
       .setUsername("user")
       .setPassword("secret")
       .setHost("localhost");
@@ -73,9 +71,9 @@ public class PgConnectionUriParserTest {
   @Test
   public void testParsingHost() {
     uri = "postgresql://localhost";
-    actualParsedOptions = translateToPgPoolOptions(uri);
+    actualParsedOptions = fromUri(uri);
 
-    expectedParsedOptions = new PgPoolOptions()
+    expectedParsedOptions = new PgConnectOptions()
       .setHost("localhost");
 
     assertEquals(expectedParsedOptions, actualParsedOptions);
@@ -84,9 +82,9 @@ public class PgConnectionUriParserTest {
   @Test
   public void testParsingIpv4Address() {
     uri = "postgresql://192.168.1.1:1234";
-    actualParsedOptions = translateToPgPoolOptions(uri);
+    actualParsedOptions = fromUri(uri);
 
-    expectedParsedOptions = new PgPoolOptions()
+    expectedParsedOptions = new PgConnectOptions()
       .setHost("192.168.1.1")
       .setPort(1234);
 
@@ -96,9 +94,9 @@ public class PgConnectionUriParserTest {
   @Test
   public void testParsingIpv6Address() {
     uri = "postgresql://[2001:db8::1234]/mydb";
-    actualParsedOptions = translateToPgPoolOptions(uri);
+    actualParsedOptions = fromUri(uri);
 
-    expectedParsedOptions = new PgPoolOptions()
+    expectedParsedOptions = new PgConnectOptions()
       .setHost("2001:db8::1234")
       .setDatabase("mydb");
 
@@ -108,9 +106,9 @@ public class PgConnectionUriParserTest {
   @Test
   public void testParsingPort() {
     uri = "postgresql://localhost:1234";
-    actualParsedOptions = translateToPgPoolOptions(uri);
+    actualParsedOptions = fromUri(uri);
 
-    expectedParsedOptions = new PgPoolOptions()
+    expectedParsedOptions = new PgConnectOptions()
       .setHost("localhost")
       .setPort(1234);
 
@@ -121,9 +119,9 @@ public class PgConnectionUriParserTest {
   @Test
   public void testParsingDbName() {
     uri = "postgres://localhost/mydb";
-    actualParsedOptions = translateToPgPoolOptions(uri);
+    actualParsedOptions = fromUri(uri);
 
-    expectedParsedOptions = new PgPoolOptions()
+    expectedParsedOptions = new PgConnectOptions()
       .setHost("localhost")
       .setDatabase("mydb");
 
@@ -134,9 +132,9 @@ public class PgConnectionUriParserTest {
   @Test
   public void testParsingParameter() {
     uri = "postgresql://localhost/otherdb?user=other";
-    actualParsedOptions = translateToPgPoolOptions(uri);
+    actualParsedOptions = fromUri(uri);
 
-    expectedParsedOptions = new PgPoolOptions()
+    expectedParsedOptions = new PgConnectOptions()
       .setUsername("other")
       .setHost("localhost")
       .setDatabase("otherdb");
@@ -147,9 +145,9 @@ public class PgConnectionUriParserTest {
   @Test
   public void testParsingParameters() {
     uri = "postgresql://localhost/otherdb?user=other&password=secret&port=1234";
-    actualParsedOptions = translateToPgPoolOptions(uri);
+    actualParsedOptions = fromUri(uri);
 
-    expectedParsedOptions = new PgPoolOptions()
+    expectedParsedOptions = new PgConnectOptions()
       .setHost("localhost")
       .setDatabase("otherdb")
       .setUsername("other")
@@ -162,9 +160,9 @@ public class PgConnectionUriParserTest {
   @Test
   public void testParsingHostAndParameters() {
     uri = "postgresql://localhost?user=other&password=secret";
-    actualParsedOptions = translateToPgPoolOptions(uri);
+    actualParsedOptions = fromUri(uri);
 
-    expectedParsedOptions = new PgPoolOptions()
+    expectedParsedOptions = new PgConnectOptions()
       .setHost("localhost")
       .setUsername("other")
       .setPassword("secret");
@@ -175,9 +173,9 @@ public class PgConnectionUriParserTest {
   @Test
   public void testParsingUserWithoutPassword() {
     uri = "postgresql://user@";
-    actualParsedOptions = translateToPgPoolOptions(uri);
+    actualParsedOptions = fromUri(uri);
 
-    expectedParsedOptions = new PgPoolOptions()
+    expectedParsedOptions = new PgConnectOptions()
       .setUsername("user");
 
     assertEquals(expectedParsedOptions, actualParsedOptions);
@@ -186,9 +184,9 @@ public class PgConnectionUriParserTest {
   @Test
   public void testParsingPasswordWithoutUsername() {
     uri = "postgresql://:secret@";
-    actualParsedOptions = translateToPgPoolOptions(uri);
+    actualParsedOptions = fromUri(uri);
 
-    expectedParsedOptions = new PgPoolOptions();
+    expectedParsedOptions = new PgConnectOptions();
 
     assertEquals(expectedParsedOptions, actualParsedOptions);
   }
@@ -197,9 +195,9 @@ public class PgConnectionUriParserTest {
   public void testParsingPortWithoutHost() {
     // This URI is not valid in java.net.URI
     uri = "postgresql://:1234";
-    actualParsedOptions = translateToPgPoolOptions(uri);
+    actualParsedOptions = fromUri(uri);
 
-    expectedParsedOptions = new PgPoolOptions()
+    expectedParsedOptions = new PgConnectOptions()
       .setPort(1234);
 
     assertEquals(expectedParsedOptions, actualParsedOptions);
@@ -208,9 +206,9 @@ public class PgConnectionUriParserTest {
   @Test
   public void testParsingOnlyDbName() {
     uri = "postgresql:///mydb";
-    actualParsedOptions = translateToPgPoolOptions(uri);
+    actualParsedOptions = fromUri(uri);
 
-    expectedParsedOptions = new PgPoolOptions()
+    expectedParsedOptions = new PgConnectOptions()
       .setDatabase("mydb");
 
     assertEquals(expectedParsedOptions, actualParsedOptions);
@@ -219,9 +217,9 @@ public class PgConnectionUriParserTest {
   @Test
   public void testParsingOnlyParameters() {
     uri = "postgresql://?host=localhost&port=1234";
-    actualParsedOptions = translateToPgPoolOptions(uri);
+    actualParsedOptions = fromUri(uri);
 
-    expectedParsedOptions = new PgPoolOptions()
+    expectedParsedOptions = new PgConnectOptions()
       .setHost("localhost")
       .setPort(1234);
 
@@ -231,9 +229,9 @@ public class PgConnectionUriParserTest {
   @Test
   public void testParsingDomainSocket() {
     uri = "postgresql://%2Fvar%2Flib%2Fpostgresql/dbname";
-    actualParsedOptions = translateToPgPoolOptions(uri);
+    actualParsedOptions = fromUri(uri);
 
-    expectedParsedOptions = new PgPoolOptions()
+    expectedParsedOptions = new PgConnectOptions()
       .setDatabase("dbname");
 
     assertEquals(expectedParsedOptions, actualParsedOptions);
@@ -242,9 +240,9 @@ public class PgConnectionUriParserTest {
   @Test
   public void testParsingDomainSocketInParameter() {
     uri = "postgresql:///dbname?host=/var/lib/postgresql";
-    actualParsedOptions = translateToPgPoolOptions(uri);
+    actualParsedOptions = fromUri(uri);
 
-    expectedParsedOptions = new PgPoolOptions()
+    expectedParsedOptions = new PgConnectOptions()
       .setDatabase("dbname");
 
     assertEquals(expectedParsedOptions, actualParsedOptions);
@@ -253,9 +251,9 @@ public class PgConnectionUriParserTest {
   @Test
   public void testParsingInvalidUri() {
     uri = "postgresql://@@/dbname?host";
-    actualParsedOptions = translateToPgPoolOptions(uri);
+    actualParsedOptions = fromUri(uri);
 
-    expectedParsedOptions = new PgPoolOptions();
+    expectedParsedOptions = new PgConnectOptions();
 
     assertEquals(expectedParsedOptions, actualParsedOptions);
   }
@@ -263,9 +261,9 @@ public class PgConnectionUriParserTest {
   @Test
   public void testParsingUriWithOverridenParameters() {
     uri = "postgresql://localhost/mydb?host=myhost&port=1234";
-    actualParsedOptions = translateToPgPoolOptions(uri);
+    actualParsedOptions = fromUri(uri);
 
-    expectedParsedOptions = new PgPoolOptions()
+    expectedParsedOptions = new PgConnectOptions()
       .setHost("myhost")
       .setDatabase("mydb")
       .setPort(1234);
@@ -276,9 +274,9 @@ public class PgConnectionUriParserTest {
   @Test
   public void testParsingFullUri() {
     uri = "postgresql://dbuser:secretpassword@database.server.com:3211/mydb";
-    actualParsedOptions = translateToPgPoolOptions(uri);
+    actualParsedOptions = fromUri(uri);
 
-    expectedParsedOptions = new PgPoolOptions()
+    expectedParsedOptions = new PgConnectOptions()
       .setUsername("dbuser")
       .setPassword("secretpassword")
       .setHost("database.server.com")
@@ -294,13 +292,13 @@ public class PgConnectionUriParserTest {
       .setPort(3211)
       .setDatabase("mydb");
 
-    PgConnectOptions actualPgConnectOptions = PgConnectionUriParser.translateToPgConnectOptions(uri);
+    PgConnectOptions actualPgConnectOptions = fromUri(uri);
 
     assertEquals(expectedPgConnectOptions, actualPgConnectOptions);
   }
 
   @Test
-  public void testConvertingPgConnectOptions() {
+  public void testProvidingPgConnectOptions() {
     uri = "postgresql://pg@localhost?password=secret123&port=1234";
 
     PgConnectOptions expectedOptions = new PgConnectOptions()
@@ -309,11 +307,11 @@ public class PgConnectionUriParserTest {
       .setHost("localhost")
       .setPort(1234);
 
-    assertEquals(expectedOptions, translateToPgConnectOptions(uri));
+    assertEquals(expectedOptions, fromUri(uri));
   }
 
   @Test
-  public void testConvertingWrongPgConnectOptions() {
+  public void testProvidingWrongPgConnectOptions() {
     uri = "postgresql://user:secret@localhost/mydb?port=1234";
 
     PgConnectOptions wrongOptions = new PgConnectOptions()
@@ -322,15 +320,15 @@ public class PgConnectionUriParserTest {
       .setHost("localhost")
       .setPort(1234);
 
-    assertNotEquals(wrongOptions, translateToPgConnectOptions(uri));
+    assertNotEquals(wrongOptions, fromUri(uri));
   }
 
   @Test
   public void testInvalidUri1() {
     uri = "postgresql://us@er@@";
-    actualParsedOptions = translateToPgPoolOptions(uri);
+    actualParsedOptions = fromUri(uri);
 
-    expectedParsedOptions = new PgPoolOptions();
+    expectedParsedOptions = new PgConnectOptions();
 
     assertEquals(expectedParsedOptions, actualParsedOptions);
   }
@@ -338,9 +336,9 @@ public class PgConnectionUriParserTest {
   @Test
   public void testInvalidUri2() {
     uri = "postgresql://user/mydb//";
-    actualParsedOptions = translateToPgPoolOptions(uri);
+    actualParsedOptions = fromUri(uri);
 
-    expectedParsedOptions = new PgPoolOptions();
+    expectedParsedOptions = new PgConnectOptions();
 
     assertEquals(expectedParsedOptions, actualParsedOptions);
   }
@@ -348,9 +346,9 @@ public class PgConnectionUriParserTest {
   @Test
   public void testInvalidUri3() {
     uri = "postgresql:///dbname/?host=localhost";
-    actualParsedOptions = translateToPgPoolOptions(uri);
+    actualParsedOptions = fromUri(uri);
 
-    expectedParsedOptions = new PgPoolOptions();
+    expectedParsedOptions = new PgConnectOptions();
 
     assertEquals(expectedParsedOptions, actualParsedOptions);
   }
@@ -358,9 +356,9 @@ public class PgConnectionUriParserTest {
   @Test
   public void testInvalidUri4() {
     uri = "postgresql://user::1234";
-    actualParsedOptions = translateToPgPoolOptions(uri);
+    actualParsedOptions = fromUri(uri);
 
-    expectedParsedOptions = new PgPoolOptions();
+    expectedParsedOptions = new PgConnectOptions();
 
     assertEquals(expectedParsedOptions, actualParsedOptions);
   }
@@ -368,9 +366,9 @@ public class PgConnectionUriParserTest {
   @Test
   public void testInvalidUri5() {
     uri = "postgresql://@:1234";
-    actualParsedOptions = translateToPgPoolOptions(uri);
+    actualParsedOptions = fromUri(uri);
 
-    expectedParsedOptions = new PgPoolOptions();
+    expectedParsedOptions = new PgConnectOptions();
 
     assertEquals(expectedParsedOptions, actualParsedOptions);
   }
@@ -378,9 +376,9 @@ public class PgConnectionUriParserTest {
   @Test
   public void testInvalidUri6() {
     uri = "postgresql://:123:";
-    actualParsedOptions = translateToPgPoolOptions(uri);
+    actualParsedOptions = fromUri(uri);
 
-    expectedParsedOptions = new PgPoolOptions();
+    expectedParsedOptions = new PgConnectOptions();
 
     assertEquals(expectedParsedOptions, actualParsedOptions);
   }


### PR DESCRIPTION
Add feature for connecting with connection URI. Fixes https://github.com/reactiverse/reactive-pg-client/issues/40.