### PR TITLE
Java>=10 does not contain the xml bind package anymore

### DIFF
--- a/src/main/java/io/reactiverse/pgclient/impl/codec/util/MD5Authentication.java
+++ b/src/main/java/io/reactiverse/pgclient/impl/codec/util/MD5Authentication.java
@@ -17,7 +17,6 @@
 
 package io.reactiverse.pgclient.impl.codec.util;
 
-import javax.xml.bind.annotation.adapters.HexBinaryAdapter;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
@@ -25,9 +24,19 @@ import static java.nio.charset.StandardCharsets.*;
 
 public class MD5Authentication {
 
-  public static String encode(String username, String password, byte[] salt) {
+  private final static char[] HEX_ALPHABET = "0123456789abcdef".toCharArray();
 
-    HexBinaryAdapter hex = new HexBinaryAdapter();
+  private static String toHex(byte[] bytes) {
+    char[] hexChars = new char[bytes.length * 2];
+    for ( int j = 0; j < bytes.length; j++ ) {
+      int v = bytes[j] & 0xFF;
+      hexChars[j * 2] = HEX_ALPHABET[v >>> 4];
+      hexChars[j * 2 + 1] = HEX_ALPHABET[v & 0x0F];
+    }
+    return new String(hexChars);
+  }
+
+  public static String encode(String username, String password, byte[] salt) {
 
     byte[] digest, passDigest;
 
@@ -44,12 +53,12 @@ public class MD5Authentication {
     messageDigest.update(username.getBytes(UTF_8));
     digest = messageDigest.digest();
 
-    byte[] hexDigest = hex.marshal(digest).toLowerCase().getBytes(US_ASCII);
+    byte[] hexDigest = toHex(digest).getBytes(US_ASCII);
 
     messageDigest.update(hexDigest);
     messageDigest.update(salt);
     passDigest = messageDigest.digest();
 
-    return "md5" + hex.marshal(passDigest).toLowerCase();
+    return "md5" + toHex(passDigest);
   }
 }

--- a/src/test/java/io/reactiverse/pgclient/impl/codec/util/MD5AuthenticationTest.java
+++ b/src/test/java/io/reactiverse/pgclient/impl/codec/util/MD5AuthenticationTest.java
@@ -1,0 +1,17 @@
+package io.reactiverse.pgclient.impl.codec.util;
+
+import org.junit.Test;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.Assert.*;
+
+public class MD5AuthenticationTest {
+
+  @Test
+  public void encodeTest() {
+    assertEquals(
+      "md54cd35160716308e3e571bbba12bb7591",
+      MD5Authentication.encode("scott", "tiger", "salt'n'pepper".getBytes(StandardCharsets.UTF_8)));
+  }
+}


### PR DESCRIPTION
the current build does not run on java >= 10 because:

```
Unhandled exception java.lang.NoClassDefFoundError: javax/xml/bind/annotation/adapters/HexBinaryAdapter
        at io.reactiverse.pgclient.impl.codec.util.MD5Authentication.encode(MD5Authentication.java:30)
        at io.reactiverse.pgclient.impl.codec.encoder.message.PasswordMessage.<init>(PasswordMessage.java:37)
 ```

This PR replaces the removed API with a single function that does the hex string encoding and adds a test to verify that the expected result matches what the old API was generating.