### PR TITLE
Use quoted identifiers in LISTEN / UNLISTEN

### DIFF
--- a/src/main/docs/index.md
+++ b/src/main/docs/index.md
@@ -400,6 +400,13 @@ provides per channel subscription:
 {@link examples.Examples#pubsub02(io.vertx.core.Vertx)}
 ```
 
+The channel name that is given to the channel method will be the exact name of the channel as held by Postgres for sending
+notifications.  Note this is different than the representation of the channel name in SQL, and
+internally {@link io.reactiverse.pgclient.pubsub.PgSubscriber} will prepare the submitted channel name as a quoted identifier:
+
+```$lang
+{@link examples.Examples#pubsub03(io.vertx.core.Vertx)}
+```
 You can provide a reconnect policy as a function that takes the number of `retries` as argument and returns an `amountOfTime`
 value:
 
@@ -408,7 +415,7 @@ value:
 * when `amountOfTime > 0`: the subscriber retries after `amountOfTime` milliseconds
 
 ```$lang
-{@link examples.Examples#pubsub03(io.vertx.core.Vertx)}
+{@link examples.Examples#pubsub04(io.vertx.core.Vertx)}
 ```
 
 The default policy is to not reconnect.

--- a/src/main/java/io/reactiverse/pgclient/impl/pubsub/PgSubscriberImpl.java
+++ b/src/main/java/io/reactiverse/pgclient/impl/pubsub/PgSubscriberImpl.java
@@ -198,7 +198,7 @@ public class PgSubscriberImpl implements PgSubscriber {
 
     ChannelList(String name) {
       this.name = name;
-	  quotedName = "\"" + name + "\"";
+	  quotedName = "\"" + name.replace("\"", "\"\"") + "\"";
     }
 
     void add(ChannelImpl sub) {

--- a/src/main/java/io/reactiverse/pgclient/impl/pubsub/PgSubscriberImpl.java
+++ b/src/main/java/io/reactiverse/pgclient/impl/pubsub/PgSubscriberImpl.java
@@ -47,6 +47,15 @@ public class PgSubscriberImpl implements PgSubscriber {
     this.options = new PgConnectOptions(options);
   }
 
+  // Identifiers in PostgreSQL are currently limited to NAMEDATALEN-1 = 63
+  // characters (see PostgreSQL lexical structure documentation)
+  public static final int NAMEDATALEN = 64;
+  public static final int MAX_CHANNEL_NAME_LENGTH = NAMEDATALEN - 1;
+  public static String applyIdLengthLimit(String channelName) {
+  	return channelName.length() > MAX_CHANNEL_NAME_LENGTH
+  			? channelName.substring(0, MAX_CHANNEL_NAME_LENGTH) : channelName;
+  }
+
   private void handleNotification(PgNotification notif) {
     List<Handler<String>> handlers = new ArrayList<>();
     synchronized (this) {
@@ -195,7 +204,7 @@ public class PgSubscriberImpl implements PgSubscriber {
 	final String quotedName;
     final ArrayList<ChannelImpl> subs = new ArrayList<>();
     boolean subscribed;
-
+    
     ChannelList(String name) {
       this.name = name;
 	  quotedName = "\"" + name.replace("\"", "\"\"") + "\"";
@@ -246,7 +255,7 @@ public class PgSubscriberImpl implements PgSubscriber {
     private boolean paused;
 
     ChannelImpl(String name) {
-      this.name = name;
+      this.name = applyIdLengthLimit(name);
     }
 
     @Override

--- a/src/main/java/io/reactiverse/pgclient/impl/pubsub/PgSubscriberImpl.java
+++ b/src/main/java/io/reactiverse/pgclient/impl/pubsub/PgSubscriberImpl.java
@@ -171,7 +171,7 @@ public class PgSubscriberImpl implements PgSubscriber {
           .stream()
           .map(channel -> {
             channel.subscribed = true;
-            return channel.name;
+            return channel.quotedName;
           })
           .collect(Collectors.joining(";LISTEN ", "LISTEN ", ""));
         conn.query(sql, ar2 -> {
@@ -192,11 +192,13 @@ public class PgSubscriberImpl implements PgSubscriber {
   private class ChannelList {
 
     final String name;
+	final String quotedName;
     final ArrayList<ChannelImpl> subs = new ArrayList<>();
     boolean subscribed;
 
     ChannelList(String name) {
       this.name = name;
+	  quotedName = "\"" + name + "\"";
     }
 
     void add(ChannelImpl sub) {
@@ -204,7 +206,7 @@ public class PgSubscriberImpl implements PgSubscriber {
       if (!subscribed) {
         if (conn != null) {
           subscribed = true;
-          String sql = "LISTEN " + name;
+          String sql = "LISTEN " + quotedName;
           conn.query(sql, ar -> {
             if (ar.succeeded()) {
               Handler<Void> handler = sub.subscribeHandler;
@@ -224,7 +226,7 @@ public class PgSubscriberImpl implements PgSubscriber {
       if (subs.isEmpty()) {
         channels.remove(name, this);
         if (conn != null) {
-          conn.query("UNLISTEN " + name, ar -> {
+          conn.query("UNLISTEN " + quotedName, ar -> {
             if (ar.failed()) {
               log.error("Cannot UNLISTEN channel " + name, ar.cause());
             }

--- a/src/main/java/io/reactiverse/pgclient/pubsub/PgSubscriber.java
+++ b/src/main/java/io/reactiverse/pgclient/pubsub/PgSubscriber.java
@@ -50,6 +50,23 @@ public interface PgSubscriber {
    * Return a channel for the given {@code name}.
    *
    * @param name the channel name
+   * <p/>
+   * This will be the name of the channel exactly as held by Postgres for sending
+   * notifications.  Internally this name will be truncated to the Postgres identifier
+   * maxiumum length of {@code (NAMEDATALEN = 64) - 1 == 63} characters, and prepared
+   * as a quoted identifier without unicode escape sequence support for use in
+   * {@code LISTEN/UNLISTEN} commands.  Examples of channel names and corresponding
+   * {@code NOTIFY} commands:
+   * <ul>
+   *   <li>when {@code name == "the_channel"}: {@code NOTIFY the_channel, 'msg'},
+   *   {@code NOTIFY The_Channel, 'msg'}, or {@code NOTIFY "the_channel", 'msg'}
+   *   succeed in delivering a message to the created channel
+   *   </li>
+   *   <li>when {@code name == "The_Channel"}: {@code NOTIFY "The_Channel", 'msg'},
+   *   succeeds in delivering a message to the created channel
+   *   </li>
+   *   <li></li>
+   * </ul>
    * @return the channel
    */
   PgChannel channel(String name);

--- a/src/test/java/io/reactiverse/pgclient/PubSubTest.java
+++ b/src/test/java/io/reactiverse/pgclient/PubSubTest.java
@@ -51,15 +51,24 @@ public class PubSubTest extends PgTestBase {
 
   @Test
   public void testNotify(TestContext ctx) {
+	  testNotify(ctx, "the_channel");
+  }
+  
+  @Test
+  public void testNotifyChannelRequiresQuotedID(TestContext ctx) {
+	  testNotify(ctx, "The.Channel");
+  }
+  
+  public void testNotify(TestContext ctx, String channelName) {
     Async async = ctx.async(2);
     PgClient.connect(vertx, options, ctx.asyncAssertSuccess(conn -> {
-      conn.query("LISTEN the_channel", ctx.asyncAssertSuccess(result1 -> {
+      conn.query("LISTEN \"" + channelName + "\"", ctx.asyncAssertSuccess(result1 -> {
         conn.notificationHandler(notification -> {
-          ctx.assertEquals("the_channel", notification.getChannel());
+          ctx.assertEquals(channelName, notification.getChannel());
           ctx.assertEquals("the message", notification.getPayload());
           async.countDown();
         });
-        conn.query("NOTIFY the_channel, 'the message'", ctx.asyncAssertSuccess(result2 -> {
+        conn.query("NOTIFY \"" + channelName + "\", 'the message'", ctx.asyncAssertSuccess(result2 -> {
           async.countDown();
         }));
       }));
@@ -68,10 +77,19 @@ public class PubSubTest extends PgTestBase {
 
   @Test
   public void testConnect(TestContext ctx) {
+    testConnect(ctx, "channel1", "channel2");
+  }
+  
+  @Test
+  public void testConnectChannelRequiresQuotedID(TestContext ctx) {
+    testConnect(ctx, "Channel.Test.1", "Channel.Test.2");
+  }
+  
+  private void testConnect(TestContext ctx, String channel1Name, String channel2Name) {
     subscriber = PgSubscriber.subscriber(vertx, options);
     Async notifiedLatch = ctx.async();
-    PgChannel sub1 = subscriber.channel("channel1");
-    PgChannel sub2 = subscriber.channel("channel2");
+    PgChannel sub1 = subscriber.channel(channel1Name);
+    PgChannel sub2 = subscriber.channel(channel2Name);
     sub1.handler(notif -> {
       ctx.assertEquals("msg1", notif);
       notifiedLatch.countDown();
@@ -83,32 +101,50 @@ public class PubSubTest extends PgTestBase {
     Async connectLatch = ctx.async();
     subscriber.connect(ctx.asyncAssertSuccess(v -> connectLatch.complete()));
     connectLatch.awaitSuccess(10000);
-    subscriber.actualConnection().query("NOTIFY channel1, 'msg1'", ctx.asyncAssertSuccess());
-    subscriber.actualConnection().query("NOTIFY channel2, 'msg2'", ctx.asyncAssertSuccess());
+    subscriber.actualConnection().query("NOTIFY \"" + channel1Name + "\", 'msg1'", ctx.asyncAssertSuccess());
+    subscriber.actualConnection().query("NOTIFY \"" + channel2Name + "\", 'msg2'", ctx.asyncAssertSuccess());
     notifiedLatch.awaitSuccess(10000);
   }
 
   @Test
   public void testSubscribe(TestContext ctx) {
-    subscriber = PgSubscriber.subscriber(vertx, options);
-    Async connectLatch = ctx.async();
-    subscriber.connect(ctx.asyncAssertSuccess(v -> connectLatch.complete()));
-    connectLatch.awaitSuccess(10000);
-    PgChannel channel = subscriber.channel("the_channel");
-    Async subscribedLatch = ctx.async();
-    ctx.assertEquals(channel, channel.subscribeHandler(v -> subscribedLatch.complete()));
-    Async notifiedLatch = ctx.async();
-    channel.handler(notif -> {
-      ctx.assertEquals("msg", notif);
-      notifiedLatch.countDown();
-    });
-    subscribedLatch.awaitSuccess(10000);
-    subscriber.actualConnection().query("NOTIFY the_channel, 'msg'", ctx.asyncAssertSuccess());
-    notifiedLatch.awaitSuccess(10000);
+    testSubscribe(ctx, "the_channel");
   }
+  
+  @Test
+  public void testSubscribeChannelRequiresQuotedID(TestContext ctx) {
+    testSubscribe(ctx, "The.Channel");
+  }
+  
+  public void testSubscribe(TestContext ctx, String channelName) {
+	    subscriber = PgSubscriber.subscriber(vertx, options);
+	    Async connectLatch = ctx.async();
+	    subscriber.connect(ctx.asyncAssertSuccess(v -> connectLatch.complete()));
+	    connectLatch.awaitSuccess(10000);
+	    PgChannel channel = subscriber.channel(channelName);
+	    Async subscribedLatch = ctx.async();
+	    ctx.assertEquals(channel, channel.subscribeHandler(v -> subscribedLatch.complete()));
+	    Async notifiedLatch = ctx.async();
+	    channel.handler(notif -> {
+	      ctx.assertEquals("msg", notif);
+	      notifiedLatch.countDown();
+	    });
+	    subscribedLatch.awaitSuccess(10000);
+	    subscriber.actualConnection().query("NOTIFY \"" + channelName + "\", 'msg'", ctx.asyncAssertSuccess());
+	    notifiedLatch.awaitSuccess(10000);
+	  }
 
   @Test
   public void testUnsubscribe(TestContext ctx) {
+	testUnsubscribe(ctx, "the_channel");
+  }
+  
+  @Test
+  public void testUnsubscribeChannelRequiresQuotedID(TestContext ctx) {
+	testUnsubscribe(ctx, "The.Channel");
+  }
+  
+  public void testUnsubscribe(TestContext ctx, String channelName) {
     subscriber = PgSubscriber.subscriber(vertx, options);
     Async connectLatch = ctx.async();
     subscriber.connect(ctx.asyncAssertSuccess(v -> connectLatch.complete()));
@@ -127,15 +163,25 @@ public class PubSubTest extends PgTestBase {
 
   @Test
   public void testReconnectImmediately(TestContext ctx) {
-    testReconnect(ctx, 0);
+    testReconnect(ctx, 0, "the_channel");
+  }
+  
+  @Test
+  public void testReconnectImmediatelyChannelRequiresQuotedID(TestContext ctx) {
+    testReconnect(ctx, 0, "The.Channel");
   }
 
   @Test
   public void testReconnectWithDelay(TestContext ctx) {
-    testReconnect(ctx, 100);
+    testReconnect(ctx, 100, "the_channel");
   }
 
-  public void testReconnect(TestContext ctx, long delay) {
+  @Test
+  public void testReconnectWithDelayChannelRequiresQuotedID(TestContext ctx) {
+    testReconnect(ctx, 100, "The.Channel");
+  }
+
+  public void testReconnect(TestContext ctx, long delay, String channelName) {
     PgConnectOptions options = new PgConnectOptions(PgTestBase.options);
     ProxyServer proxy = ProxyServer.create(vertx, options.getPort(), options.getHost());
     AtomicReference<ProxyServer.Connection> connRef = new AtomicReference<>();
@@ -150,7 +196,7 @@ public class PubSubTest extends PgTestBase {
     }));
     listenLatch.awaitSuccess(10000);
     subscriber = PgSubscriber.subscriber(vertx, options);
-    PgChannel sub = subscriber.channel("the_channel");
+    PgChannel sub = subscriber.channel(channelName);
     Async connect1Latch = ctx.async();
     Async connect2Latch = ctx.async();
     Async connect3Latch = ctx.async();
@@ -195,8 +241,17 @@ public class PubSubTest extends PgTestBase {
 
   @Test
   public void testClose(TestContext ctx) {
+	  testClose(ctx, "the_channel");
+  }
+  
+  @Test
+  public void testCloseChannelRequiresQuotedID(TestContext ctx) {
+	  testClose(ctx, "The.Channel");
+  }
+  
+  public void testClose(TestContext ctx, String channelName) {
     PgSubscriber subscriber = PgSubscriber.subscriber(vertx, options);
-    PgChannel sub = subscriber.channel("the_channel");
+    PgChannel sub = subscriber.channel(channelName);
     Async endLatch = ctx.async();
     sub.endHandler(v -> endLatch.complete());
     sub.handler(notif -> {

--- a/src/test/java/io/reactiverse/pgclient/PubSubTest.java
+++ b/src/test/java/io/reactiverse/pgclient/PubSubTest.java
@@ -17,6 +17,7 @@
 package io.reactiverse.pgclient;
 
 import io.reactiverse.pgclient.pubsub.PgSubscriber;
+import io.reactiverse.pgclient.impl.pubsub.PgSubscriberImpl;
 import io.reactiverse.pgclient.pubsub.PgChannel;
 import io.vertx.core.Vertx;
 import io.vertx.ext.unit.Async;
@@ -27,6 +28,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -122,6 +124,16 @@ public class PubSubTest extends PgTestBase {
   @Test
   public void testSubscribeChannelContainsQuotes(TestContext ctx) {
     testSubscribe(ctx, "\"The\".\"Channel\"");
+  }
+  
+  @Test
+  public void testSubscribeChannelExceedsLengthLimit(TestContext ctx) {
+	char[] channelNameChars = new char[PgSubscriberImpl.MAX_CHANNEL_NAME_LENGTH + 5];
+	Arrays.fill(channelNameChars, 0, PgSubscriberImpl.MAX_CHANNEL_NAME_LENGTH, 'a');
+	Arrays.fill(channelNameChars, PgSubscriberImpl.MAX_CHANNEL_NAME_LENGTH,
+			channelNameChars.length, 'b');
+	String channelName = new String(channelNameChars);
+    testSubscribe(ctx, channelName);
   }
   
   public void testSubscribe(TestContext ctx, String channelName) {

--- a/src/test/java/io/reactiverse/pgclient/PubSubTest.java
+++ b/src/test/java/io/reactiverse/pgclient/PubSubTest.java
@@ -133,6 +133,25 @@ public class PubSubTest extends PgTestBase {
 	    subscriber.actualConnection().query("NOTIFY \"" + channelName + "\", 'msg'", ctx.asyncAssertSuccess());
 	    notifiedLatch.awaitSuccess(10000);
 	  }
+  
+  @Test
+  public void testSubscribeNotifyWithUnquotedId(TestContext ctx) {
+	    subscriber = PgSubscriber.subscriber(vertx, options);
+	    Async connectLatch = ctx.async();
+	    subscriber.connect(ctx.asyncAssertSuccess(v -> connectLatch.complete()));
+	    connectLatch.awaitSuccess(10000);
+	    PgChannel channel = subscriber.channel("the_channel");
+	    Async subscribedLatch = ctx.async();
+	    ctx.assertEquals(channel, channel.subscribeHandler(v -> subscribedLatch.complete()));
+	    Async notifiedLatch = ctx.async();
+	    channel.handler(notif -> {
+	      ctx.assertEquals("msg", notif);
+	      notifiedLatch.countDown();
+	    });
+	    subscribedLatch.awaitSuccess(10000);
+	    subscriber.actualConnection().query("NOTIFY The_Channel, 'msg'", ctx.asyncAssertSuccess());
+	    notifiedLatch.awaitSuccess(10000);
+	  }
 
   @Test
   public void testUnsubscribe(TestContext ctx) {


### PR DESCRIPTION
Bug Fix: Using quoted identifiers for channel names would result in notifications not coming back to the channel since the PgNotification would contain a channel name without quotes.  Solved this by making all channel statements use quoted identifiers - this also matches up with use of a standard HashMap (case-sensitive) to match back to channels.