### PR TITLE
Treat unknown datatypes as text instead of binary

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -236,13 +236,19 @@ The *Reactive Postgres Client* currently supports the following data types
 |`i.r.p.Json[]`
 |&#10004;
 
+|`UNKNOWN`
+|`j.l.String`
+|&#10004;
+|`j.l.String[]`
+|&#10004;
+
 |====
 
 The following types
 
 _SERIAL2_, _SERIAL4_, _SERIAL8_, _MONEY_, _BIT_, _VARBIT_, _MACADDR_, _INET_, _CIDR_, _MACADDR8_,
 _XML_, _POINT_, _PATH_, _BOX_, _LINE_, _POLYGON_, _LSEG_, _CIRCLE_, _HSTORE_, _OID_,
-_VOID_, _UNKOWN_, _TSQUERY_, _TSVECTOR_
+_VOID_, _TSQUERY_, _TSVECTOR_
 
 are not implemented yet (PR are welcome).
 

--- a/docker/postgres/resources/create-postgres.sql
+++ b/docker/postgres/resources/create-postgres.sql
@@ -1,4 +1,7 @@
+DROP TYPE IF EXISTS weather CASCADE;
 DROP TYPE IF EXISTS mood CASCADE;
+
+CREATE TYPE weather AS ENUM ('sunny', 'cloudy', 'rainy');
 CREATE TYPE mood AS ENUM ('unhappy', 'ok', 'happy');
 
 -- World table
@@ -170,10 +173,11 @@ INSERT INTO "ArrayDataType" VALUES (2, ARRAY [TRUE],
 DROP TABLE IF EXISTS "EnumDataType";
 CREATE TABLE "EnumDataType" (
   "id" INTEGER NOT NULL PRIMARY KEY,
-  "currentMood" mood
+  "currentMood" mood,
+  "currentWeather" weather
 );
-INSERT INTO "EnumDataType" ("id", "currentMood") VALUES (1, 'ok');
-INSERT INTO "EnumDataType" ("id", "currentMood") VALUES (2, 'unhappy');
-INSERT INTO "EnumDataType" ("id", "currentMood") VALUES (3, 'happy');
-INSERT INTO "EnumDataType" ("id", "currentMood") VALUES (4, null);
-INSERT INTO "EnumDataType" ("id", "currentMood") VALUES (5, 'ok');
+INSERT INTO "EnumDataType" ("id", "currentMood", "currentWeather") VALUES (1, 'ok', 'sunny');
+INSERT INTO "EnumDataType" ("id", "currentMood", "currentWeather") VALUES (2, 'unhappy', 'cloudy');
+INSERT INTO "EnumDataType" ("id", "currentMood", "currentWeather") VALUES (3, 'happy', 'rainy');
+INSERT INTO "EnumDataType" ("id", "currentMood", "currentWeather") VALUES (4, null, null);
+INSERT INTO "EnumDataType" ("id", "currentMood", "currentWeather") VALUES (5, 'ok', 'sunny');

--- a/docker/postgres/resources/create-postgres.sql
+++ b/docker/postgres/resources/create-postgres.sql
@@ -1,8 +1,11 @@
 DROP TYPE IF EXISTS weather CASCADE;
 DROP TYPE IF EXISTS mood CASCADE;
+DROP TYPE IF EXISTS full_address CASCADE;
 
 CREATE TYPE weather AS ENUM ('sunny', 'cloudy', 'rainy');
 CREATE TYPE mood AS ENUM ('unhappy', 'ok', 'happy');
+
+CREATE TYPE full_address AS (city TEXT, street TEXT, home BOOLEAN);
 
 -- World table
 DROP TABLE IF EXISTS World;
@@ -123,7 +126,8 @@ CREATE TABLE "ArrayDataType" (
   "JSON"           JSON[],
   "JSONB"          JSONB[],
   "Enum"           mood[],
-  "Interval"       INTERVAL []
+  "Interval"       INTERVAL [],
+  "CustomType"     full_address[]
 );
 INSERT INTO "ArrayDataType" VALUES (1, ARRAY [TRUE],
                                        ARRAY [1],
@@ -146,7 +150,8 @@ INSERT INTO "ArrayDataType" VALUES (1, ARRAY [TRUE],
                                        ARRAY ['  {"str":"blah", "int" : 1, "float" : 3.5, "object": {}, "array" : []   }' :: JSON, '[1,true,null,9.5,"Hi"]' :: JSON, '4' :: JSON, '"Hello World"' :: JSON, 'true' :: JSON, 'false' :: JSON, 'null' :: JSON],
                                        ARRAY ['  {"str":"blah", "int" : 1, "float" : 3.5, "object": {}, "array" : []   }' :: JSON, '[1,true,null,9.5,"Hi"]' :: JSON, '4' :: JSON, '"Hello World"' :: JSON, 'true' :: JSON, 'false' :: JSON, 'null' :: JSON],
                                        ARRAY['ok'::mood,'unhappy'::mood, 'happy'::mood],
-                                       ARRAY['10 years 3 months 332 days 20 hours 20 minutes 20.999991 seconds'::INTERVAL, '20 minutes 20.123456 seconds'::INTERVAL, '30 months ago'::INTERVAL]);
+                                       ARRAY['10 years 3 months 332 days 20 hours 20 minutes 20.999991 seconds'::INTERVAL, '20 minutes 20.123456 seconds'::INTERVAL, '30 months ago'::INTERVAL],
+                                       ARRAY [ROW('Anytown', 'Main St', true)::full_address, ('Anytown', 'First St', false)::full_address]);
 INSERT INTO "ArrayDataType" VALUES (2, ARRAY [TRUE],
                                        ARRAY [1],
                                        ARRAY [2],
@@ -167,8 +172,8 @@ INSERT INTO "ArrayDataType" VALUES (2, ARRAY [TRUE],
                                        ARRAY ['  {"str":"blah", "int" : 1, "float" : 3.5, "object": {}, "array" : []   }' :: JSON, '[1,true,null,9.5,"Hi"]' :: JSON, '4' :: JSON, '"Hello World"' :: JSON, 'true' :: JSON, 'false' :: JSON, 'null' :: JSON],
                                        ARRAY ['  {"str":"blah", "int" : 1, "float" : 3.5, "object": {}, "array" : []   }' :: JSON, '[1,true,null,9.5,"Hi"]' :: JSON, '4' :: JSON, '"Hello World"' :: JSON, 'true' :: JSON, 'false' :: JSON, 'null' :: JSON],
                                        ARRAY['unhappy'::mood, 'happy'::mood],
-                                       ARRAY['0 years 0 months 0 days 0 hours 0 minutes 0 seconds'::INTERVAL]);
-
+                                       ARRAY['0 years 0 months 0 days 0 hours 0 minutes 0 seconds'::INTERVAL],
+                                       ARRAY [ROW('Anytown', 'Main St', true)::full_address, ('Anytown', 'First St', false)::full_address]);
 
 DROP TABLE IF EXISTS "EnumDataType";
 CREATE TABLE "EnumDataType" (
@@ -181,3 +186,11 @@ INSERT INTO "EnumDataType" ("id", "currentMood", "currentWeather") VALUES (2, 'u
 INSERT INTO "EnumDataType" ("id", "currentMood", "currentWeather") VALUES (3, 'happy', 'rainy');
 INSERT INTO "EnumDataType" ("id", "currentMood", "currentWeather") VALUES (4, null, null);
 INSERT INTO "EnumDataType" ("id", "currentMood", "currentWeather") VALUES (5, 'ok', 'sunny');
+
+DROP TABLE IF EXISTS "CustomDataType";
+CREATE TABLE "CustomDataType" (
+  "id" INTEGER NOT NULL PRIMARY KEY,
+  "address" full_address
+);
+INSERT INTO "CustomDataType" ("id", "address") VALUES (1, ('Anytown', 'Main St', true));
+INSERT INTO "CustomDataType" ("id", "address") VALUES (2, ('Anytown', 'First St', false));

--- a/docker/postgres_tc/create-postgres.sql
+++ b/docker/postgres_tc/create-postgres.sql
@@ -1,8 +1,12 @@
 DROP TYPE IF EXISTS weather CASCADE;
 DROP TYPE IF EXISTS mood CASCADE;
+DROP TYPE IF EXISTS full_address CASCADE;
 
 CREATE TYPE weather AS ENUM ('sunny', 'cloudy', 'rainy');
 CREATE TYPE mood AS ENUM ('unhappy', 'ok', 'happy');
+
+CREATE TYPE full_address AS (city TEXT, street TEXT, home BOOLEAN);
+
 DROP TABLE IF EXISTS World;
 CREATE TABLE  World (
   id integer NOT NULL,
@@ -155,7 +159,8 @@ CREATE TABLE "ArrayDataType" (
   "JSON"           JSON[],
   "JSONB"          JSONB[],
   "Enum"           mood[],
-  "Interval"       INTERVAL []
+  "Interval"       INTERVAL [],
+  "CustomType"     full_address[]
 );
 INSERT INTO "ArrayDataType" VALUES (1, ARRAY [TRUE],
                                        ARRAY [1],
@@ -178,7 +183,8 @@ INSERT INTO "ArrayDataType" VALUES (1, ARRAY [TRUE],
                                        ARRAY ['  {"str":"blah", "int" : 1, "float" : 3.5, "object": {}, "array" : []   }' :: JSON, '[1,true,null,9.5,"Hi"]' :: JSON, '4' :: JSON, '"Hello World"' :: JSON, 'true' :: JSON, 'false' :: JSON, 'null' :: JSON],
                                        ARRAY ['  {"str":"blah", "int" : 1, "float" : 3.5, "object": {}, "array" : []   }' :: JSON, '[1,true,null,9.5,"Hi"]' :: JSON, '4' :: JSON, '"Hello World"' :: JSON, 'true' :: JSON, 'false' :: JSON, 'null' :: JSON],
                                        ARRAY['ok'::mood,'unhappy'::mood, 'happy'::mood],
-                                       ARRAY['10 years 3 months 332 days 20 hours 20 minutes 20.999991 seconds'::INTERVAL, '20 minutes 20.123456 seconds'::INTERVAL, '30 months ago'::INTERVAL]);
+                                       ARRAY['10 years 3 months 332 days 20 hours 20 minutes 20.999991 seconds'::INTERVAL, '20 minutes 20.123456 seconds'::INTERVAL, '30 months ago'::INTERVAL],
+                                       ARRAY [ROW('Anytown', 'Main St', true)::full_address, ('Anytown', 'First St', false)::full_address]);
 INSERT INTO "ArrayDataType" VALUES (2, ARRAY [TRUE],
                                        ARRAY [1],
                                        ARRAY [2],
@@ -199,8 +205,8 @@ INSERT INTO "ArrayDataType" VALUES (2, ARRAY [TRUE],
                                        ARRAY ['  {"str":"blah", "int" : 1, "float" : 3.5, "object": {}, "array" : []   }' :: JSON, '[1,true,null,9.5,"Hi"]' :: JSON, '4' :: JSON, '"Hello World"' :: JSON, 'true' :: JSON, 'false' :: JSON, 'null' :: JSON],
                                        ARRAY ['  {"str":"blah", "int" : 1, "float" : 3.5, "object": {}, "array" : []   }' :: JSON, '[1,true,null,9.5,"Hi"]' :: JSON, '4' :: JSON, '"Hello World"' :: JSON, 'true' :: JSON, 'false' :: JSON, 'null' :: JSON],
                                        ARRAY['unhappy'::mood, 'happy'::mood],
-                                       ARRAY['0 years 0 months 0 days 0 hours 0 minutes 0 seconds'::INTERVAL]);
-
+                                       ARRAY['0 years 0 months 0 days 0 hours 0 minutes 0 seconds'::INTERVAL],
+                                       ARRAY [ROW('Anytown', 'Main St', true)::full_address, ('Anytown', 'First St', false)::full_address]);
 
 DROP TABLE IF EXISTS "EnumDataType";
 CREATE TABLE "EnumDataType" (
@@ -213,3 +219,11 @@ INSERT INTO "EnumDataType" ("id", "currentMood", "currentWeather") VALUES (2, 'u
 INSERT INTO "EnumDataType" ("id", "currentMood", "currentWeather") VALUES (3, 'happy', 'rainy');
 INSERT INTO "EnumDataType" ("id", "currentMood", "currentWeather") VALUES (4, null, null);
 INSERT INTO "EnumDataType" ("id", "currentMood", "currentWeather") VALUES (5, 'ok', 'sunny');
+
+DROP TABLE IF EXISTS "CustomDataType";
+CREATE TABLE "CustomDataType" (
+  "id" INTEGER NOT NULL PRIMARY KEY,
+  "address" full_address
+);
+INSERT INTO "CustomDataType" ("id", "address") VALUES (1, ('Anytown', 'Main St', true));
+INSERT INTO "CustomDataType" ("id", "address") VALUES (2, ('Anytown', 'First St', false));

--- a/docker/postgres_tc/create-postgres.sql
+++ b/docker/postgres_tc/create-postgres.sql
@@ -1,4 +1,7 @@
+DROP TYPE IF EXISTS weather CASCADE;
 DROP TYPE IF EXISTS mood CASCADE;
+
+CREATE TYPE weather AS ENUM ('sunny', 'cloudy', 'rainy');
 CREATE TYPE mood AS ENUM ('unhappy', 'ok', 'happy');
 DROP TABLE IF EXISTS World;
 CREATE TABLE  World (
@@ -202,10 +205,11 @@ INSERT INTO "ArrayDataType" VALUES (2, ARRAY [TRUE],
 DROP TABLE IF EXISTS "EnumDataType";
 CREATE TABLE "EnumDataType" (
   "id" INTEGER NOT NULL PRIMARY KEY,
-  "currentMood" mood
+  "currentMood" mood,
+  "currentWeather" weather
 );
-INSERT INTO "EnumDataType" ("id", "currentMood") VALUES (1, 'ok');
-INSERT INTO "EnumDataType" ("id", "currentMood") VALUES (2, 'unhappy');
-INSERT INTO "EnumDataType" ("id", "currentMood") VALUES (3, 'happy');
-INSERT INTO "EnumDataType" ("id", "currentMood") VALUES (4, null);
-INSERT INTO "EnumDataType" ("id", "currentMood") VALUES (5, 'ok');
+INSERT INTO "EnumDataType" ("id", "currentMood", "currentWeather") VALUES (1, 'ok', 'sunny');
+INSERT INTO "EnumDataType" ("id", "currentMood", "currentWeather") VALUES (2, 'unhappy', 'cloudy');
+INSERT INTO "EnumDataType" ("id", "currentMood", "currentWeather") VALUES (3, 'happy', 'rainy');
+INSERT INTO "EnumDataType" ("id", "currentMood", "currentWeather") VALUES (4, null, null);
+INSERT INTO "EnumDataType" ("id", "currentMood", "currentWeather") VALUES (5, 'ok', 'sunny');

--- a/docs/guide/groovy/index.md
+++ b/docs/guide/groovy/index.md
@@ -615,6 +615,7 @@ Currently the client supports the following Postgres types
 * JSON (`io.reactiverse.pgclient.data.Json`)
 * JSONB (`io.reactiverse.pgclient.data.Json`)
 * POINT (`io.reactiverse.pgclient.data.Point`)
+* UNKNOWN (`java.lang.String`)
 
 Arrays of these types are supported.
 
@@ -662,6 +663,34 @@ Arrays are available on [`Tuple`](../../apidocs/io/reactiverse/pgclient/Tuple.ht
 
 ```groovy
 Code not translatable
+```
+
+## Handling Custom Types
+
+Java `String` is used to represent custom types, both sent to and returned from Postgres.
+
+```groovy
+client.preparedQuery("INSERT INTO address_book (id, address) VALUES ($1, $2)", Tuple.of(3, "('Anytown', 'Second Ave', false)"),  { ar ->
+  if (ar.succeeded()) {
+    def rows = ar.result()
+    println(rows.rowCount())
+  } else {
+    println("Failure: ${ar.cause().getMessage()}")
+  }
+})
+```
+
+```groovy
+client.preparedQuery("SELECT address, (address).city FROM address_book WHERE id=$1", Tuple.of(3),  { ar ->
+ if (ar.succeeded()) {
+    def rows = ar.result()
+    rows.each { row ->
+      println("Full Address ${row.getString(0)}, City ${row.getString(1)}")
+    }
+  } else {
+    println("Failure: ${ar.cause().getMessage()}")
+  }
+})
 ```
 
 ## Collector queries

--- a/docs/guide/java/index.md
+++ b/docs/guide/java/index.md
@@ -624,6 +624,7 @@ Currently the client supports the following Postgres types
 * JSON (`io.reactiverse.pgclient.data.Json`)
 * JSONB (`io.reactiverse.pgclient.data.Json`)
 * POINT (`io.reactiverse.pgclient.data.Point`)
+* UNKNOWN (`java.lang.String`)
 
 Arrays of these types are supported.
 
@@ -674,6 +675,34 @@ tuple.addStringArray(new String[]{"another", "array"});
 
 // Get the first array of string
 String[] array = tuple.getStringArray(0);
+```
+
+## Handling Custom Types
+
+Java `String` is used to represent custom types, both sent to and returned from Postgres.
+
+```java
+client.preparedQuery("INSERT INTO address_book (id, address) VALUES ($1, $2)", Tuple.of(3, "('Anytown', 'Second Ave', false)"),  ar -> {
+  if (ar.succeeded()) {
+    PgRowSet rows = ar.result();
+    System.out.println(rows.rowCount());
+  } else {
+    System.out.println("Failure: " + ar.cause().getMessage());
+  }
+});
+```
+
+```java
+client.preparedQuery("SELECT address, (address).city FROM address_book WHERE id=$1", Tuple.of(3),  ar -> {
+  if (ar.succeeded()) {
+    PgRowSet rows = ar.result();
+    for (Row row : rows) {
+       System.out.println("Full Address " + row.getString(0) + ", City " + row.getString(1));
+    }
+  } else {
+    System.out.println("Failure: " + ar.cause().getMessage());
+  }
+});
 ```
 
 ## Collector queries

--- a/docs/guide/js/index.md
+++ b/docs/guide/js/index.md
@@ -631,6 +631,7 @@ Currently the client supports the following Postgres types
 * JSON (`io.reactiverse.pgclient.data.Json`)
 * JSONB (`io.reactiverse.pgclient.data.Json`)
 * POINT (`io.reactiverse.pgclient.data.Point`)
+* UNKNOWN (`java.lang.String`)
 
 Arrays of these types are supported.
 
@@ -680,6 +681,34 @@ Arrays are available on [`Tuple`](../../jsdoc/module-reactive-pg-client-js_tuple
 
 ```js
 Code not translatable
+```
+
+## Handling Custom Types
+
+Java `String` is used to represent custom types, both sent to and returned from Postgres.
+
+```js
+client.preparedQuery("INSERT INTO address_book (id, address) VALUES ($1, $2)", Tuple.of(3, "('Anytown', 'Second Ave', false)"),  function (res, res_err) {
+  if (res_err == null) {
+    // Process rows
+    var rows = res;
+  } else {
+    console.log("Batch failed " + res_err);
+  }
+});
+```
+
+```js
+client.preparedQuery("SELECT address, (address).city FROM address_book WHERE id=$1", Tuple.of(3),  function (res, res_err) {
+  if (ar_err == null) {
+    var rows = ar;
+    Array.prototype.forEach.call(rows, function(row) {
+      console.log("Full Address " + row.getString(0) + ", City " + row.getString(1));
+    });
+  } else {
+    console.log("Failure: " + ar_err.getMessage());
+  }
+});
 ```
 
 ## Collector queries

--- a/docs/guide/kotlin/index.md
+++ b/docs/guide/kotlin/index.md
@@ -610,6 +610,7 @@ Currently the client supports the following Postgres types
 * JSON (`io.reactiverse.pgclient.data.Json`)
 * JSONB (`io.reactiverse.pgclient.data.Json`)
 * POINT (`io.reactiverse.pgclient.data.Point`)
+* UNKNOWN (`java.lang.String`)
 
 Arrays of these types are supported.
 
@@ -657,6 +658,35 @@ Arrays are available on [`Tuple`](../../apidocs/io/reactiverse/pgclient/Tuple.ht
 
 ```kotlin
 Code not translatable
+```
+
+
+## Handling Custom Types
+
+Java `String` is used to represent custom types, both sent to and returned from Postgres.
+
+```kotlin
+client.preparedQuery("INSERT INTO address_book (id, address) VALUES (\$$1, \$$2)", Tuple.of(3, "('Anytown', 'Second Ave', false)"), { ar ->
+  if (ar.succeeded()) {
+    var rows = ar.result()
+    println("Got ${rows.size()} rows ")
+  } else {
+    println("Failure: ${ar.cause().getMessage()}")
+  }
+})
+```
+
+```kotlin
+client.preparedQuery("SELECT address, (address).city FROM address_book WHERE id=\$$1", Tuple.of(3),  { ar ->
+  if (ar.succeeded()) {
+    var rows = ar.result()
+    for (row in rows) {
+      println("Full Address ${row.getString(0)}, City ${row.getString(1)}")
+    }
+  } else {
+    println("Failure: ${ar.cause().getMessage()}")
+  }
+})
 ```
 
 ## Collector queries

--- a/docs/guide/ruby/index.md
+++ b/docs/guide/ruby/index.md
@@ -631,6 +631,7 @@ Currently the client supports the following Postgres types
 * JSON (`io.reactiverse.pgclient.data.Json`)
 * JSONB (`io.reactiverse.pgclient.data.Json`)
 * POINT (`io.reactiverse.pgclient.data.Point`)
+* UNKNOWN (`java.lang.String`)
 
 Arrays of these types are supported.
 
@@ -680,6 +681,36 @@ Arrays are available on [`Tuple`](../../yardoc/ReactivePgClient/Tuple.html) and 
 
 ```ruby
 Code not translatable
+```
+
+## Handling Custom Types
+
+Java `String` is used to represent custom types, both sent to and returned from Postgres.
+
+```ruby
+require 'reactive-pg-client/tuple'
+client.preparedQuery("INSERT INTO address_book (id, address) VALUES ($1, $2)", ReactivePgClient::Tuple.of(3, "('Anytown', 'Second Ave', false)"),  { |ar_err,ar|
+  if (ar_err == nil)
+    rows = ar
+    puts rows.row_count()
+  else
+    puts "Failure: #{ar_err.get_message()}"
+  end
+}
+```
+
+```ruby
+require 'reactive-pg-client/tuple'
+client.preparedQuery("SELECT address, (address).city FROM address_book WHERE id=$1", ReactivePgClient::Tuple.of(3), { |ar_err,ar|
+  if (ar_err == nil)
+    rows = ar
+    rows.each do |row|
+      puts "Full Address #{row.get_string(0)}, City #{row.get_string(1)}"
+    end
+  else
+    puts "Failure: #{ar_err.get_message()}"
+  end
+}
 ```
 
 ## Collector queries

--- a/src/main/java/io/reactiverse/pgclient/impl/codec/DataType.java
+++ b/src/main/java/io/reactiverse/pgclient/impl/codec/DataType.java
@@ -98,9 +98,7 @@ public enum DataType {
   OID(26, true, Object.class),
   OID_ARRAY(1028, true, Object[].class),
   VOID(2278, true, Object.class),
-  ENUM(16385, true, String.class),
-  ENUM_ARRAY(16384, true, String[].class),
-  UNKNOWN(705, true, Object.class);
+  UNKNOWN(705, false, String.class);
 
   public final int id;
   public final boolean supportsBinary;

--- a/src/main/java/io/reactiverse/pgclient/impl/codec/DataTypeCodec.java
+++ b/src/main/java/io/reactiverse/pgclient/impl/codec/DataTypeCodec.java
@@ -479,7 +479,8 @@ public class DataTypeCodec {
 
   private static Object defaultDecodeText(int len, ByteBuf buff) {
     // decode unknown text values as text or as an array if it begins with `{`
-    if (buff.readableBytes() > 0 && buff.getByte(buff.readerIndex()) == '{') {
+    final int idx = buff.readerIndex();
+    if (idx < buff.writerIndex() && buff.getByte(idx) == '{') {
       if (len == 2) {
         buff.skipBytes(2);
         return empty_string_array;

--- a/src/main/java/io/reactiverse/pgclient/impl/codec/DataTypeCodec.java
+++ b/src/main/java/io/reactiverse/pgclient/impl/codec/DataTypeCodec.java
@@ -479,8 +479,9 @@ public class DataTypeCodec {
 
   private static Object defaultDecodeText(int len, ByteBuf buff) {
     // decode unknown text values as text or as an array if it begins with `{`
-    if (buff.getByte(buff.readerIndex()) == '{') {
+    if (buff.readableBytes() > 0 && buff.getByte(buff.readerIndex()) == '{') {
       if (len == 2) {
+        buff.skipBytes(2);
         return empty_string_array;
       }
       return textDecodeArray(STRING_ARRAY_FACTORY, DataType.TEXT, len - 1, buff);

--- a/src/test/java/io/reactiverse/pgclient/DataTypeExtendedEncodingTest.java
+++ b/src/test/java/io/reactiverse/pgclient/DataTypeExtendedEncodingTest.java
@@ -281,6 +281,30 @@ public class DataTypeExtendedEncodingTest extends DataTypeTestBase {
   }
 
   @Test
+  public void testEncodeCustomType(TestContext ctx) {
+    Async async = ctx.async();
+    String actual = "('Othercity',\" 'Second Ave'\",f)";
+    PgClient.connect(vertx, options, ctx.asyncAssertSuccess(conn -> {
+      conn.prepare("UPDATE \"CustomDataType\" SET \"address\" = $1  WHERE \"id\" = $2 RETURNING \"address\"",
+        ctx.asyncAssertSuccess(p -> {
+          p.execute(Tuple.tuple()
+              .addString("('Othercity', 'Second Ave', false)")
+              .addInteger(2)
+            , ctx.asyncAssertSuccess(result -> {
+              ctx.assertEquals(1, result.size());
+              ctx.assertEquals(1, result.rowCount());
+              Row row = result.iterator().next();
+              ColumnChecker.checkColumn(0, "address")
+                .returns(Tuple::getValue, Row::getValue, actual)
+                .returns(Tuple::getString, Row::getString, actual)
+                .forRow(row);
+              async.complete();
+            }));
+        }));
+    }));
+  }
+
+  @Test
   public void testDecodeFloat4(TestContext ctx) {
     Async async = ctx.async();
     PgClient.connect(vertx, options, ctx.asyncAssertSuccess(conn -> {
@@ -1761,7 +1785,7 @@ public class DataTypeExtendedEncodingTest extends DataTypeTestBase {
   public void testEncodeEnumArrayEmptyValues(TestContext ctx) {
     Async async = ctx.async();
     PgClient.connect(vertx, options, ctx.asyncAssertSuccess(conn -> {
-      conn.prepare("UPDATE \"ArrayDataType\" SET \"Enum\" = $1 WHERE \"id\" = $2 RETURNING \"Enum\"",
+      conn.prepare("UPDATE \"ArrayDataType\" SET \"Enum\" = $1 WHERE \"id\" = $2 RETURNING \"Enum\", \"Boolean\"",
         ctx.asyncAssertSuccess(p -> {
           p.execute(Tuple.tuple()
               .addStringArray(new String[]{})
@@ -1770,6 +1794,10 @@ public class DataTypeExtendedEncodingTest extends DataTypeTestBase {
               ColumnChecker.checkColumn(0, "Enum")
                 .returns(Tuple::getValue, Row::getValue, new String[]{})
                 .returns(Tuple::getStringArray, Row::getStringArray, new String[]{})
+                .forRow(result.iterator().next());
+              ColumnChecker.checkColumn(1, "Boolean")
+                .returns(Tuple::getValue, Row::getValue, new Boolean[]{true})
+                .returns(Tuple::getBooleanArray, Row::getBooleanArray, new Boolean[]{true})
                 .forRow(result.iterator().next());
               async.complete();
             }));

--- a/src/test/java/io/reactiverse/pgclient/DataTypeExtendedEncodingTest.java
+++ b/src/test/java/io/reactiverse/pgclient/DataTypeExtendedEncodingTest.java
@@ -1738,6 +1738,46 @@ public class DataTypeExtendedEncodingTest extends DataTypeTestBase {
   }
 
   @Test
+  public void testEncodeEnumArrayMultipleValues(TestContext ctx) {
+    Async async = ctx.async();
+    PgClient.connect(vertx, options, ctx.asyncAssertSuccess(conn -> {
+      conn.prepare("UPDATE \"ArrayDataType\" SET \"Enum\" = $1 WHERE \"id\" = $2 RETURNING \"Enum\"",
+        ctx.asyncAssertSuccess(p -> {
+          p.execute(Tuple.tuple()
+              .addStringArray(new String[]{"unhappy", "ok"})
+              .addInteger(2)
+            , ctx.asyncAssertSuccess(result -> {
+              ColumnChecker.checkColumn(0, "Enum")
+                .returns(Tuple::getValue, Row::getValue, new String[]{"unhappy", "ok"})
+                .returns(Tuple::getStringArray, Row::getStringArray, new String[]{"unhappy", "ok"})
+                .forRow(result.iterator().next());
+              async.complete();
+            }));
+        }));
+    }));
+  }
+
+  @Test
+  public void testEncodeEnumArrayEmptyValues(TestContext ctx) {
+    Async async = ctx.async();
+    PgClient.connect(vertx, options, ctx.asyncAssertSuccess(conn -> {
+      conn.prepare("UPDATE \"ArrayDataType\" SET \"Enum\" = $1 WHERE \"id\" = $2 RETURNING \"Enum\"",
+        ctx.asyncAssertSuccess(p -> {
+          p.execute(Tuple.tuple()
+              .addStringArray(new String[]{})
+              .addInteger(2)
+            , ctx.asyncAssertSuccess(result -> {
+              ColumnChecker.checkColumn(0, "Enum")
+                .returns(Tuple::getValue, Row::getValue, new String[]{})
+                .returns(Tuple::getStringArray, Row::getStringArray, new String[]{})
+                .forRow(result.iterator().next());
+              async.complete();
+            }));
+        }));
+    }));
+  }
+
+  @Test
   public void testDecodeLocalDateArray(TestContext ctx) {
     Async async = ctx.async();
     PgClient.connect(vertx, options, ctx.asyncAssertSuccess(conn -> {

--- a/src/test/java/io/reactiverse/pgclient/DataTypeSimpleEncodingTest.java
+++ b/src/test/java/io/reactiverse/pgclient/DataTypeSimpleEncodingTest.java
@@ -507,6 +507,24 @@ public class DataTypeSimpleEncodingTest extends DataTypeTestBase {
   }
 
   @Test
+  public void testCustomType(TestContext ctx) {
+    Async async = ctx.async();
+    String expected = "Anytown";
+    PgClient.connect(vertx, options, ctx.asyncAssertSuccess(conn -> {
+      conn
+        .query("SELECT (address).city FROM \"CustomDataType\"", ctx.asyncAssertSuccess(result -> {
+          ctx.assertEquals(2, result.size());
+          Row row = result.iterator().next();
+          ColumnChecker.checkColumn(0, "city")
+            .returns(Tuple::getValue, Row::getValue, expected)
+            .returns(Tuple::getString, Row::getString, expected)
+            .forRow(row);
+          async.complete();
+        }));
+    }));
+  }
+
+  @Test
   public void testJSONB(TestContext ctx) {
     testJson(ctx, "JSONB");
   }
@@ -703,6 +721,13 @@ public class DataTypeSimpleEncodingTest extends DataTypeTestBase {
   public void testDecodeJSONBArray(TestContext ctx) {
     testDecodeXXXArray(ctx, "JSONB", "ArrayDataType", Tuple::getJsonArray, Row::getJsonArray,
       expected);
+  }
+
+  @Test
+  public void testDecodeCustomTypeArray(TestContext ctx) {
+    String [] addresses = new String [] {"(Anytown,\"Main St\",t)", "(Anytown,\"First St\",f)"};
+
+    testDecodeXXXArray(ctx, "CustomType", "ArrayDataType", Tuple::getStringArray, Row::getStringArray, addresses);
   }
 
   private <T> void testDecodeXXXArray(TestContext ctx,


### PR DESCRIPTION
The current implementation treats unknown as binary, which deviates from other postgres drivers. This issue manifests in the current support for reading enum and enum array values.

This PR:
- Removes the existing enum implementation (the oid was for the text fixture enum, not for enums in general)
- Changes `DataType.UNKNOWN` to be a String instead of a binary type
- Updates encoders and decoders to handle both Strings and array values
- Adds a few tests around array parsing (empties, 1+, etc)

For a point of reference, both the [postres driver](https://github.com/pgjdbc/pgjdbc/blob/9534e9ca0e1840445ad5f4eee75bc1e2ac102dde/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java#L220) and[ Postgres Async](https://github.com/mauricio/postgresql-async/blob/5d0a7e017e90f137a9cb0b0e20947c6bc8817b0a/postgresql-async/src/main/scala/com/github/mauricio/async/db/postgresql/column/PostgreSQLColumnDecoderRegistry.scala#L121) default to this behavior.