### PR TITLE
A simple test for numeric typing

### DIFF
--- a/src/test/java/io/reactiverse/pgclient/DataTypeWideningTest.java
+++ b/src/test/java/io/reactiverse/pgclient/DataTypeWideningTest.java
@@ -1,0 +1,28 @@
+package io.reactiverse.pgclient;
+
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import org.junit.Test;
+
+public class DataTypeWideningTest extends DataTypeTestBase {
+
+  @Override
+  protected PgConnectOptions options() {
+    return new PgConnectOptions(options).setCachePreparedStatements(false);
+  }
+
+  @Test
+  public void testIntegerToLong(TestContext ctx) {
+    Async async = ctx.async();
+    PgClient.connect(vertx, options, ctx.asyncAssertSuccess(conn -> {
+      conn
+        .prepare("SELECT * FROM \"NumericDataType\" WHERE \"Long\"=$1", ctx.asyncAssertSuccess(preparedQuery -> {
+          preparedQuery.execute(Tuple.of(Integer.valueOf(5)), ctx.asyncAssertSuccess(result -> {
+            ctx.assertEquals(0, result.size());
+            async.complete();
+          }));
+        }));
+    }));
+  }
+
+}


### PR DESCRIPTION
That gives the error message `Values [5] cannot be coerced to [Long]` which is
at least missleading.

Demonstrating #179