### PR TITLE
Two minor changes in docker file and instructions for using tc to add latency

### DIFF
--- a/docker/postgres_tc/Dockerfile
+++ b/docker/postgres_tc/Dockerfile
@@ -2,6 +2,5 @@ FROM postgres
 ENV POSTGRES_DB postgres
 ENV POSTGRES_USER postgres
 ENV POSTGRES_PASSWORD postgres
-RUN apt-get update
-RUN apt-get install -y iproute
+RUN apt-get update && apt-get install -y iproute
 COPY create-postgres.sql /docker-entrypoint-initdb.d/

--- a/docker/postgres_tc/README.md
+++ b/docker/postgres_tc/README.md
@@ -15,5 +15,5 @@ Running the container
 Add one 1 ms latency to eth0
 
 ```
-> docker exec -it julien-test tc qdisc add dev eth0 root netem delay 1ms
+> docker exec -it test-postgres_tc tc qdisc add dev eth0 root netem delay 1ms
 ```


### PR DESCRIPTION
Hi @vietj.  I was following the instructions for setting up a system with a network latency (in the postgres_tc folder), and came across two minor issues, so here's a suggested PR with a couple of changes you might want to consider:
- The instructions referred to a container called `julien-test`, but the previous step created it with a name of `test-postgres_tc` (at least as far as I understand). So I guess they should both be using the same name?
- The supplied Dockerfile didn't work for me, and I tracked it down to a recommendation from Docker that when using `apt-get` you should combine `update` and `install` into the same `RUN` statement. Details in this SO answer: https://stackoverflow.com/a/42981752/10326373

Hope this is of some use.