### PR TITLE
Better SSL failure handling when connecting to non SSL Postgres server - fixes #206

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -325,10 +325,11 @@ You can run tests with an external database:
 You need to add some properties for testing:
 
 ```
-> mvn test -Dconnection.uri=postgres://$username:$password@$host:$port/$database -Dunix.socket.directory=$path
+> mvn test -Dconnection.uri=postgres://$username:$password@$host:$port/$database -Dtls.connection.uri=postgres://$username:$password@$host:$port/$database -Dunix.socket.directory=$path
 ```
 
 - connection.uri(mandatory): configure the client to connect the specified database
+- tls.connection.uri(mandatory): configure the client to run `TLSTest` with the specified Postgres with SSL enabled
 - unix.socket.directory(optional): the single unix socket directory(multiple socket directories are not supported) to test Unix domain socket with a specified database, domain socket tests will be skipped if this property is not specified
 (Note: Make sure you can access the unix domain socket with this directory under your host machine)
 - unix.socket.port(optional): unix socket file is named `.s.PGSQL.nnnn` and `nnnn` is the server's port number,
@@ -337,17 +338,17 @@ you will then need this property to help you connect the Postgres with Unix doma
 
 === Testing with Docker
 
-Create and run the following docker image:
+Run the Postgres containers with `docker-compose`:
 
 ```
-> docker build -t test/postgres docker/postgres
-> docker run --rm --name test-postgres -v /var/run/postgresql:/var/run/postgresql -p 5432:5432 test/postgres
+> cd docker/postgres
+> docker-compose up --build -V
 ```
 
 Run tests:
 
 ```
-> mvn test -Dconnection.uri=postgres://postgres:postgres@localhost/postgres -Dunix.socket.directory=$path -Dunix.socket.port=$port
+> mvn test -Dconnection.uri=postgres://$username:$password@$host:$port/$database -Dtls.connection.uri=postgres://$username:$password@$host:$port/$database -Dunix.socket.directory=$path -Dunix.socket.port=$port
 ```
 
 === Documentation

--- a/README.adoc
+++ b/README.adoc
@@ -322,13 +322,15 @@ You can run tests with an external database:
 - the script `docker/postgres/resources/create-postgres.sql` creates the test data
 - the `TLSTest` expects the database to be configured with SSL with `docker/postgres/resources/server.key` / `docker/postgres/resources/server.cert``
 
-You need to override the default connection uri for testing:
+You need to add some properties for testing:
 
 ```
-> mvn test -Dconnection.uri=postgres://$username:$password@$host:$port/$database
+> mvn test -Dconnection.uri=postgres://$username:$password@$host:$port/$database -Dunix.socket.directory=$path
 ```
 
-NOTE: unix domain sockets are not testable (yet).
+- connection.uri(mandatory): configure the client to connect the specified database
+- unix.socket.directory(optional): the single unix socket directory(multiple socket directories are not supported) to test Unix domain socket with a specified database, domain socket tests will be skipped if this property is not specified
+(Note: Make sure you can access the unix domain socket with this directory under your host machine)
 
 === Testing with Docker
 
@@ -336,16 +338,14 @@ Create and run the following docker image:
 
 ```
 > docker build -t test/postgres docker/postgres
-> docker run --rm --name test-postgres -p 5432:5432 test/postgres
+> docker run --rm --name test-postgres -v /var/run/postgresql:/var/run/postgresql -p 5432:5432 test/postgres
 ```
 
 Run tests:
 
 ```
-> mvn test -Dconnection.uri=postgres://postgres:postgres@localhost/postgres
+> mvn test -Dconnection.uri=postgres://postgres:postgres@localhost/postgres -Dunix.socket.directory=$path
 ```
-
-NOTE: unix domain sockets are not testable (yet).
 
 === Documentation
 

--- a/README.adoc
+++ b/README.adoc
@@ -331,6 +331,9 @@ You need to add some properties for testing:
 - connection.uri(mandatory): configure the client to connect the specified database
 - unix.socket.directory(optional): the single unix socket directory(multiple socket directories are not supported) to test Unix domain socket with a specified database, domain socket tests will be skipped if this property is not specified
 (Note: Make sure you can access the unix domain socket with this directory under your host machine)
+- unix.socket.port(optional): unix socket file is named `.s.PGSQL.nnnn` and `nnnn` is the server's port number,
+this property is mostly used when you test with Docker, when you publish your Postgres container port other than 5432 in your host but Postgres may actually listen on a different port in the container,
+you will then need this property to help you connect the Postgres with Unix domain socket
 
 === Testing with Docker
 
@@ -344,7 +347,7 @@ Create and run the following docker image:
 Run tests:
 
 ```
-> mvn test -Dconnection.uri=postgres://postgres:postgres@localhost/postgres -Dunix.socket.directory=$path
+> mvn test -Dconnection.uri=postgres://postgres:postgres@localhost/postgres -Dunix.socket.directory=$path -Dunix.socket.port=$port
 ```
 
 === Documentation

--- a/docker/postgres/Dockerfile
+++ b/docker/postgres/Dockerfile
@@ -1,8 +1,0 @@
-FROM healthcheck/postgres:alpine
-ENV POSTGRES_DB postgres
-ENV POSTGRES_USER postgres
-ENV POSTGRES_PASSWORD postgres
-COPY ./resources/create-postgres.sql /docker-entrypoint-initdb.d/create-postgres.sql
-COPY ./resources/server.crt /server.crt
-COPY ./resources/server.key /server.key
-COPY ./ssl.sh /docker-entrypoint-initdb.d/ssl.sh

--- a/docker/postgres/README.md
+++ b/docker/postgres/README.md
@@ -3,21 +3,17 @@
 ### Build the container
 
 ```
-> docker build -t test/postgres postgres
+> docker build -t test/postgres .
 ```
 
 ### Run the container
 
 ```
-> docker run --rm --name test-postgres -p 5432:5432 test/postgres
+> docker run --rm --name test-postgres -v /var/run/postgresql:/var/run/postgresql -p 5432:5432 test/postgres
 ```
 
 ### Run tests
 
 ```
-> mvn test -Dconnection.uri=postgres://postgres:postgres@localhost/postgres
+> mvn test -Dconnection.uri=postgres://postgres:postgres@localhost/postgres -Dunix.socket.directory=/var/run/postgresql
 ```
-
-### Todo
-
-Domain socket testing

--- a/docker/postgres/README.md
+++ b/docker/postgres/README.md
@@ -1,19 +1,19 @@
-## Postgres docker file for testing
+## Postgres containers for testing
 
-### Build the container
+There will be 2 Postgres containers for testing, one with SSL enabled is for `TLSTest` and the other one with SSL disabled is for all other tests.
+
+### Configure the containers
+
+modify the content in the `docker-compose.yml`
+
+### Run the containers
 
 ```
-> docker build -t test/postgres .
-```
-
-### Run the container
-
-```
-> docker run --rm --name test-postgres -v /var/run/postgresql:/var/run/postgresql -p 5432:5432 test/postgres
+> docker-compose up --build -V
 ```
 
 ### Run tests
 
 ```
-> mvn test -Dconnection.uri=postgres://postgres:postgres@localhost/postgres -Dunix.socket.directory=/var/run/postgresql
+> mvn test -Dconnection.uri=postgres://postgres:postgres@localhost:5432/postgres -Dtls.connection.uri=postgres://postgres:postgres@localhost:5433/postgres -Dunix.socket.directory=/var/run/postgresql -Dunix.socket.port=5432
 ```

--- a/docker/postgres/docker-compose.yml
+++ b/docker/postgres/docker-compose.yml
@@ -1,0 +1,27 @@
+version: "3"
+
+services:
+  test-postgres:
+    image: healthcheck/postgres:alpine
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: postgres
+    volumes:
+      - /var/run/postgresql:/var/run/postgresql
+      - ./resources/create-postgres.sql:/docker-entrypoint-initdb.d/create-postgres.sql
+  tls-test-postgres:
+    image: healthcheck/postgres:alpine
+    ports:
+      - "5433:5432"
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: postgres
+    volumes:
+      - ./resources/create-postgres.sql:/docker-entrypoint-initdb.d/create-postgres.sql
+      - ./resources/server.crt:/server.crt
+      - ./resources/server.key:/server.key
+      - ./ssl.sh:/docker-entrypoint-initdb.d/ssl.sh

--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,7 @@
     <generated.dir>${project.basedir}/src/main/generated</generated.dir>
     <!-- Set to a value for testing with a specific database -->
     <connection.uri />
+    <tls.connection.uri />
     <unix.socket.directory />
     <unix.socket.port />
     <!-- We skip sources jar generation as we do it with the assembly plugin to have greater control over the content -->
@@ -243,6 +244,7 @@
             <systemPropertyVariables>
               <target.dir>${project.build.directory}</target.dir>
               <connection.uri>${connection.uri}</connection.uri>
+              <tls.connection.uri>${tls.connection.uri}</tls.connection.uri>
               <unix.socket.directory>${unix.socket.directory}</unix.socket.directory>
               <unix.socket.port>${unix.socket.port}</unix.socket.port>
             </systemPropertyVariables>

--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,7 @@
     <generated.dir>${project.basedir}/src/main/generated</generated.dir>
     <!-- Set to a value for testing with a specific database -->
     <connection.uri />
+    <unix.socket.directory />
     <!-- We skip sources jar generation as we do it with the assembly plugin to have greater control over the content -->
     <source.skip>true</source.skip>
     <kotlin.version>1.3.0</kotlin.version>
@@ -241,6 +242,7 @@
             <systemPropertyVariables>
               <target.dir>${project.build.directory}</target.dir>
               <connection.uri>${connection.uri}</connection.uri>
+              <unix.socket.directory>${unix.socket.directory}</unix.socket.directory>
             </systemPropertyVariables>
             <excludes>
               <exclude>io/reactiverse/pgclient/it/**</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,7 @@
     <!-- Set to a value for testing with a specific database -->
     <connection.uri />
     <unix.socket.directory />
+    <unix.socket.port />
     <!-- We skip sources jar generation as we do it with the assembly plugin to have greater control over the content -->
     <source.skip>true</source.skip>
     <kotlin.version>1.3.0</kotlin.version>
@@ -243,6 +244,7 @@
               <target.dir>${project.build.directory}</target.dir>
               <connection.uri>${connection.uri}</connection.uri>
               <unix.socket.directory>${unix.socket.directory}</unix.socket.directory>
+              <unix.socket.port>${unix.socket.port}</unix.socket.port>
             </systemPropertyVariables>
             <excludes>
               <exclude>io/reactiverse/pgclient/it/**</exclude>

--- a/src/main/java/io/reactiverse/pgclient/impl/codec/decoder/InitiateSslHandler.java
+++ b/src/main/java/io/reactiverse/pgclient/impl/codec/decoder/InitiateSslHandler.java
@@ -66,12 +66,11 @@ public class InitiateSslHandler extends ChannelInboundHandlerAdapter {
         break;
       }
       case MessageType.SSL_NO: {
-        // This case is not tested as our test db is configured for SSL
-        ctx.fireExceptionCaught(new Exception("Postgres does not handle SSL"));
+        upgradeFuture.fail(new Exception("Postgres Server does not handle SSL connection"));
         break;
       }
       default:
-        ctx.fireExceptionCaught(new Exception("Invalid connection data"));
+        upgradeFuture.fail(new Exception("Invalid SSL connection message"));
         break;
     }
   }
@@ -89,6 +88,8 @@ public class InitiateSslHandler extends ChannelInboundHandlerAdapter {
   public void channelInactive(ChannelHandlerContext ctx) throws Exception {
     super.channelInactive(ctx);
     // Work around for https://github.com/eclipse-vertx/vert.x/issues/2748
-    upgradeFuture.fail(new VertxException("SSL handshake failed", true));
+    if (!upgradeFuture.isComplete()) {
+      upgradeFuture.fail(new VertxException("SSL handshake failed", true));
+    }
   }
 }

--- a/src/test/java/io/reactiverse/pgclient/PgClientTestBase.java
+++ b/src/test/java/io/reactiverse/pgclient/PgClientTestBase.java
@@ -99,6 +99,16 @@ public abstract class PgClientTestBase<C extends PgClient> extends PgTestBase {
   }
 
   @Test
+  public void testConnectNonSSLServer(TestContext ctx) {
+    Async async = ctx.async();
+    options.setSsl(true).setTrustAll(true);
+    connector.accept(ctx.asyncAssertFailure(err -> {
+      ctx.assertEquals("Postgres Server does not handle SSL connection", err.getMessage());
+      async.complete();
+    }));
+  }
+
+  @Test
   public void testQuery(TestContext ctx) {
     Async async = ctx.async();
     connector.accept(ctx.asyncAssertSuccess(conn -> {

--- a/src/test/java/io/reactiverse/pgclient/PgTestBase.java
+++ b/src/test/java/io/reactiverse/pgclient/PgTestBase.java
@@ -60,10 +60,10 @@ public abstract class PgTestBase {
   }
 
   public synchronized static PgConnectOptions startPg() throws Exception {
-    return startPg(false);
+    return startPg(false, true);
   }
 
-  public synchronized static PgConnectOptions startPg(boolean domainSockets) throws Exception {
+  public synchronized static PgConnectOptions startPg(boolean domainSockets, boolean ssl) throws Exception {
     if (connectionUri != null && !connectionUri.isEmpty()) {
       return PgConnectOptions.fromUri(connectionUri);
     }
@@ -77,6 +77,11 @@ public abstract class PgTestBase {
       config = EmbeddedPostgres.cachedRuntimeConfig(targetDir.toPath());
     } else {
       throw new AssertionError("Cannot access target dir");
+    }
+
+    // SSL
+    if (ssl) {
+      config = useSSLRuntimeConfig(config);
     }
 
     // Domain sockets
@@ -93,48 +98,13 @@ public abstract class PgTestBase {
         PosixFilePermission.GROUP_READ,
         PosixFilePermission.GROUP_WRITE
       )));
+      config = useDomainSocketRunTimeConfig(config, sock);
     } else {
       sock = null;
     }
 
-    // SSL
-    File sslKey = getTestResource("server.key");
-    Files.setPosixFilePermissions(sslKey.toPath(), Collections.singleton(PosixFilePermission.OWNER_READ));
-    File sslCrt = getTestResource("server.crt");
-
     postgres = new EmbeddedPostgres(V9_6);
-    IRuntimeConfig sslConfig = new IRuntimeConfig() {
-      @Override
-      public ProcessOutput getProcessOutput() {
-        return config.getProcessOutput();
-      }
-      @Override
-      public ICommandLinePostProcessor getCommandLinePostProcessor() {
-        ICommandLinePostProcessor commandLinePostProcessor = config.getCommandLinePostProcessor();
-        return (distribution, args) -> {
-          List<String> result = commandLinePostProcessor.process(distribution, args);
-          if (result.get(0).endsWith("postgres")) {
-            result = new ArrayList<>(result);
-            result.add("--ssl=on");
-            result.add("--ssl_cert_file=" + sslCrt.getAbsolutePath());
-            result.add("--ssl_key_file=" + sslKey.getAbsolutePath());
-            if (domainSockets) {
-              result.add("--unix_socket_directories=" + sock.getAbsolutePath());
-            }
-          }
-          return result;
-        };
-      }
-      @Override
-      public IArtifactStore getArtifactStore() {
-        return config.getArtifactStore();
-      }
-      @Override
-      public boolean isDaemonProcess() {
-        return config.isDaemonProcess();
-      }
-    };
-    PgTestBase.postgres.start(sslConfig,
+    PgTestBase.postgres.start(config,
       "localhost",
       8081,
       "postgres",
@@ -186,6 +156,69 @@ public abstract class PgTestBase {
           completionHandler.run();
         }
       }));
+    }
+  }
+
+  private static IRuntimeConfig useSSLRuntimeConfig(IRuntimeConfig config) throws Exception {
+    File sslKey = getTestResource("server.key");
+    Files.setPosixFilePermissions(sslKey.toPath(), Collections.singleton(PosixFilePermission.OWNER_READ));
+    File sslCrt = getTestResource("server.crt");
+
+    return new RunTimeConfigBase(config) {
+      @Override
+      public ICommandLinePostProcessor getCommandLinePostProcessor() {
+        ICommandLinePostProcessor commandLinePostProcessor = config.getCommandLinePostProcessor();
+        return (distribution, args) -> {
+          List<String> result = commandLinePostProcessor.process(distribution, args);
+          if (result.get(0).endsWith("postgres")) {
+            result = new ArrayList<>(result);
+            result.add("--ssl=on");
+            result.add("--ssl_cert_file=" + sslCrt.getAbsolutePath());
+            result.add("--ssl_key_file=" + sslKey.getAbsolutePath());
+          }
+          return result;
+        };
+      }
+    };
+  }
+
+  private static IRuntimeConfig useDomainSocketRunTimeConfig(IRuntimeConfig config, File sock) throws Exception {
+    return new RunTimeConfigBase(config) {
+      @Override
+      public ICommandLinePostProcessor getCommandLinePostProcessor() {
+        ICommandLinePostProcessor commandLinePostProcessor = config.getCommandLinePostProcessor();
+        return (distribution, args) -> {
+          List<String> result = commandLinePostProcessor.process(distribution, args);
+          if (result.get(0).endsWith("postgres")) {
+            result = new ArrayList<>(result);
+            result.add("--unix_socket_directories=" + sock.getAbsolutePath());
+          }
+          return result;
+        };
+      }
+    };
+  }
+
+  private static abstract class RunTimeConfigBase implements IRuntimeConfig {
+    private final IRuntimeConfig config;
+
+    private RunTimeConfigBase(IRuntimeConfig config) {
+      this.config = config;
+    }
+
+    @Override
+    public ProcessOutput getProcessOutput() {
+      return config.getProcessOutput();
+    }
+
+    @Override
+    public IArtifactStore getArtifactStore() {
+      return config.getArtifactStore();
+    }
+
+    @Override
+    public boolean isDaemonProcess() {
+      return config.isDaemonProcess();
     }
   }
 }

--- a/src/test/java/io/reactiverse/pgclient/PgTestBase.java
+++ b/src/test/java/io/reactiverse/pgclient/PgTestBase.java
@@ -51,7 +51,7 @@ public abstract class PgTestBase {
 
   @BeforeClass
   public static void before() throws Exception {
-    options = startPg();
+    options = startPg(false, false);
   }
 
   @AfterClass

--- a/src/test/java/io/reactiverse/pgclient/PgTestBase.java
+++ b/src/test/java/io/reactiverse/pgclient/PgTestBase.java
@@ -44,14 +44,15 @@ import static ru.yandex.qatools.embed.postgresql.distribution.Version.Main.V9_6;
  */
 
 public abstract class PgTestBase {
-
   private static final String connectionUri = System.getProperty("connection.uri");
+  private static final String tlsConnectionUri = System.getProperty("tls.connection.uri");
+
   private static EmbeddedPostgres postgres;
   static PgConnectOptions options;
 
   @BeforeClass
   public static void before() throws Exception {
-    options = startPg(false, false);
+    options = startPg();
   }
 
   @AfterClass
@@ -60,10 +61,18 @@ public abstract class PgTestBase {
   }
 
   public synchronized static PgConnectOptions startPg() throws Exception {
-    return startPg(false, true);
+    return startPg(false, false);
   }
 
   public synchronized static PgConnectOptions startPg(boolean domainSockets, boolean ssl) throws Exception {
+    if (domainSockets && ssl) {
+      throw new IllegalArgumentException("ssl should be disabled when testing with Unix domain socket");
+    }
+    if (ssl) {
+      if (tlsConnectionUri != null && !tlsConnectionUri.isEmpty()) {
+        return PgConnectOptions.fromUri(tlsConnectionUri);
+      }
+    }
     if (connectionUri != null && !connectionUri.isEmpty()) {
       return PgConnectOptions.fromUri(connectionUri);
     }

--- a/src/test/java/io/reactiverse/pgclient/TLSTest.java
+++ b/src/test/java/io/reactiverse/pgclient/TLSTest.java
@@ -24,15 +24,27 @@ import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import javax.net.ssl.SSLHandshakeException;
 
 @RunWith(VertxUnitRunner.class)
-public class TLSTest extends PgTestBase {
+public class TLSTest {
 
-  Vertx vertx;
+  private static PgConnectOptions options;
+  private Vertx vertx;
+
+  @BeforeClass
+  public static void beforeClass() throws Exception {
+    options = PgTestBase.startPg(false, true);
+  }
+
+  @AfterClass
+  public static void afterClass() throws Exception {
+    PgTestBase.stopPg();
+  }
 
   @Before
   public void setup() {
@@ -47,7 +59,7 @@ public class TLSTest extends PgTestBase {
   @Test
   public void testTLS(TestContext ctx) {
     Async async = ctx.async();
-    PgConnectOptions options = new PgConnectOptions(PgTestBase.options)
+    PgConnectOptions options = new PgConnectOptions(TLSTest.options)
       .setSsl(true)
       .setPemTrustOptions(new PemTrustOptions().addCertPath("tls/server.crt"));
     PgClient.connect(vertx, new PgConnectOptions(options).setSsl(true).setTrustAll(true), ctx.asyncAssertSuccess(conn -> {

--- a/src/test/java/io/reactiverse/pgclient/TLSTest.java
+++ b/src/test/java/io/reactiverse/pgclient/TLSTest.java
@@ -23,16 +23,11 @@ import io.vertx.core.net.PemTrustOptions;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.*;
 import org.junit.runner.RunWith;
 
 @RunWith(VertxUnitRunner.class)
 public class TLSTest {
-
   private static PgConnectOptions options;
   private Vertx vertx;
 

--- a/src/test/java/io/reactiverse/pgclient/UnixDomainSocketTest.java
+++ b/src/test/java/io/reactiverse/pgclient/UnixDomainSocketTest.java
@@ -39,7 +39,7 @@ public class UnixDomainSocketTest {
     Vertx vertx = Vertx.vertx(new VertxOptions().setPreferNativeTransport(true));
     boolean nativeTransportEnabled = vertx.isNativeTransportEnabled();
     vertx.close();
-    options = PgTestBase.startPg(nativeTransportEnabled);
+    options = PgTestBase.startPg(nativeTransportEnabled, false);
   }
 
   @AfterClass

--- a/src/test/java/io/reactiverse/pgclient/UnixDomainSocketTest.java
+++ b/src/test/java/io/reactiverse/pgclient/UnixDomainSocketTest.java
@@ -24,12 +24,11 @@ import io.vertx.ext.unit.junit.VertxUnitRunner;
 import org.junit.*;
 import org.junit.runner.RunWith;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assume.assumeNotNull;
 import static org.junit.Assume.assumeTrue;
 
 @RunWith(VertxUnitRunner.class)
 public class UnixDomainSocketTest {
+  private static final String unixSocketDirectory = System.getProperty("unix.socket.directory");
 
   private static PgConnectOptions options;
   private PgPool client;
@@ -40,6 +39,9 @@ public class UnixDomainSocketTest {
     boolean nativeTransportEnabled = vertx.isNativeTransportEnabled();
     vertx.close();
     options = PgTestBase.startPg(nativeTransportEnabled, false);
+    if (unixSocketDirectory != null && !unixSocketDirectory.isEmpty()) {
+      options.setHost(unixSocketDirectory);
+    }
   }
 
   @AfterClass

--- a/src/test/java/io/reactiverse/pgclient/UnixDomainSocketTest.java
+++ b/src/test/java/io/reactiverse/pgclient/UnixDomainSocketTest.java
@@ -29,6 +29,7 @@ import static org.junit.Assume.assumeTrue;
 @RunWith(VertxUnitRunner.class)
 public class UnixDomainSocketTest {
   private static final String unixSocketDirectory = System.getProperty("unix.socket.directory");
+  private static final String unixSocketPort = System.getProperty("unix.socket.port");
 
   private static PgConnectOptions options;
   private PgPool client;
@@ -41,6 +42,9 @@ public class UnixDomainSocketTest {
     options = PgTestBase.startPg(nativeTransportEnabled, false);
     if (unixSocketDirectory != null && !unixSocketDirectory.isEmpty()) {
       options.setHost(unixSocketDirectory);
+    }
+    if (unixSocketPort != null && !unixSocketPort.isEmpty()) {
+      options.setPort(Integer.parseInt(unixSocketPort));
     }
   }
 


### PR DESCRIPTION
This PR is for #206 but with some addtional changes:
1. Add support for unit testing with non SSL embedded Postgres server and configurable for this.
2. Make all tests by default use non SSL Postgres server if necessary.

3.Expose connection failure to users directly when connecting to a non-SSL Postgres server with SSL option on.

Failure handling is more straightforward when connecting to Non SSL Postgres server like this:
```
    PgConnectOptions options = new PgConnectOptions()
      .setSsl(true)
      .setTrustAll(true)
      .setHost("localhost")
      .setPort(5432)
      .setUser("postgres")
      .setPassword("password")
      .setDatabase("postgres");

    PgClient.connect(vertx, options,
      ar -> {
        if (ar.succeeded()) {
          // not called here
        } else {
          // Expected Behavior
          // directly report to users "Postgres Server does not handle SSL connection"
          System.out.println(ar.cause().getMessage());
        }
      });
```