### PR TITLE
Add support for sslmode - fixes #207

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -329,6 +329,7 @@
                 <PGPORT>1234</PGPORT>
                 <PGUSER>test_user</PGUSER>
                 <PGPASSWORD>test_password</PGPASSWORD>
+                <PGSSLMODE>require</PGSSLMODE>
               </environmentVariables>
             </configuration>
           </execution>

--- a/src/main/asciidoc/dataobjects.adoc
+++ b/src/main/asciidoc/dataobjects.adoc
@@ -149,6 +149,7 @@
 |[[sendBufferSize]]`@sendBufferSize`|`Number (int)`|-
 |[[soLinger]]`@soLinger`|`Number (int)`|-
 |[[ssl]]`@ssl`|`Boolean`|-
+|[[sslMode]]`@sslMode`|`link:enums.html#SslMode[SslMode]`|-
 |[[tcpCork]]`@tcpCork`|`Boolean`|-
 |[[tcpFastOpen]]`@tcpFastOpen`|`Boolean`|-
 |[[tcpKeepAlive]]`@tcpKeepAlive`|`Boolean`|-
@@ -238,6 +239,7 @@ Set the maximum connection request allowed in the wait queue, any requests beyon
 |[[sendBufferSize]]`@sendBufferSize`|`Number (int)`|-
 |[[soLinger]]`@soLinger`|`Number (int)`|-
 |[[ssl]]`@ssl`|`Boolean`|-
+|[[sslMode]]`@sslMode`|`link:enums.html#SslMode[SslMode]`|-
 |[[tcpCork]]`@tcpCork`|`Boolean`|-
 |[[tcpFastOpen]]`@tcpFastOpen`|`Boolean`|-
 |[[tcpKeepAlive]]`@tcpKeepAlive`|`Boolean`|-

--- a/src/main/asciidoc/dataobjects.adoc
+++ b/src/main/asciidoc/dataobjects.adoc
@@ -149,7 +149,9 @@
 |[[sendBufferSize]]`@sendBufferSize`|`Number (int)`|-
 |[[soLinger]]`@soLinger`|`Number (int)`|-
 |[[ssl]]`@ssl`|`Boolean`|-
-|[[sslMode]]`@sslMode`|`link:enums.html#SslMode[SslMode]`|-
+|[[sslMode]]`@sslMode`|`link:enums.html#SslMode[SslMode]`|+++
+Set link for the client, this option can be used to provide different levels of secure protection.
++++
 |[[tcpCork]]`@tcpCork`|`Boolean`|-
 |[[tcpFastOpen]]`@tcpFastOpen`|`Boolean`|-
 |[[tcpKeepAlive]]`@tcpKeepAlive`|`Boolean`|-
@@ -239,7 +241,9 @@ Set the maximum connection request allowed in the wait queue, any requests beyon
 |[[sendBufferSize]]`@sendBufferSize`|`Number (int)`|-
 |[[soLinger]]`@soLinger`|`Number (int)`|-
 |[[ssl]]`@ssl`|`Boolean`|-
-|[[sslMode]]`@sslMode`|`link:enums.html#SslMode[SslMode]`|-
+|[[sslMode]]`@sslMode`|`link:enums.html#SslMode[SslMode]`|+++
+Set link for the client, this option can be used to provide different levels of secure protection.
++++
 |[[tcpCork]]`@tcpCork`|`Boolean`|-
 |[[tcpFastOpen]]`@tcpFastOpen`|`Boolean`|-
 |[[tcpKeepAlive]]`@tcpKeepAlive`|`Boolean`|-

--- a/src/main/docs/index.md
+++ b/src/main/docs/index.md
@@ -470,9 +470,8 @@ The default policy is to not reconnect.
 
 To configure the client to use SSL connection, you can configure the {@link io.reactiverse.pgclient.PgConnectOptions}
 like a Vert.x `NetClient`.
-All [SSL modes](https://www.postgresql.org/docs/current/libpq-ssl.html#LIBPQ-SSL-PROTECTION) are supported and you should always use 
-`setSslMode` instead of `setSsl` because `ssl` parameter is deprecated. `setSsl(true)` is equivalent to `setSslMode(REQUIRE)` and `setSsl(false)` is equivalent to `setSslMode(DISABLE)`.
-The client is in `DISABLE` SSL mode by default.
+All [SSL modes](https://www.postgresql.org/docs/current/libpq-ssl.html#LIBPQ-SSL-PROTECTION) are supported and you are able to configure `sslmode`. The client is in `DISABLE` SSL mode by default.
+`ssl` parameter is kept as a mere shortcut for setting `sslmode`. `setSsl(true)` is equivalent to `setSslMode(REQUIRE)` and `setSsl(false)` is equivalent to `setSslMode(DISABLE)`.
 
 ```$lang
 {@link examples.Examples#ex10}

--- a/src/main/docs/index.md
+++ b/src/main/docs/index.md
@@ -117,6 +117,7 @@ for more details. The following parameters are supported:
 * `PGDATABASE`
 * `PGUSER`
 * `PGPASSWORD`
+* `PGSSLMODE`
 
 If you don't specify a data object or a connection URI string to connect, environment variables will take precedence over them.
 
@@ -125,7 +126,8 @@ $ PGUSER=user \
   PGHOST=the-host \
   PGPASSWORD=secret \
   PGDATABASE=the-db \
-  PGPORT=5432
+  PGPORT=5432 \
+  PGSSLMODE=DISABLE
 ```
 
 ```$lang
@@ -468,6 +470,9 @@ The default policy is to not reconnect.
 
 To configure the client to use SSL connection, you can configure the {@link io.reactiverse.pgclient.PgConnectOptions}
 like a Vert.x `NetClient`.
+All [SSL modes](https://www.postgresql.org/docs/current/libpq-ssl.html#LIBPQ-SSL-PROTECTION) are supported and you should always use 
+`setSslMode` instead of `setSsl` because `ssl` parameter is deprecated. `setSsl(true)` is equivalent to `setSslMode(REQUIRE)` and `setSsl(false)` is equivalent to `setSslMode(DISABLE)`.
+The client is in `DISABLE` SSL mode by default.
 
 ```$lang
 {@link examples.Examples#ex10}

--- a/src/main/docs/index.md
+++ b/src/main/docs/index.md
@@ -471,7 +471,7 @@ The default policy is to not reconnect.
 To configure the client to use SSL connection, you can configure the {@link io.reactiverse.pgclient.PgConnectOptions}
 like a Vert.x `NetClient`.
 All [SSL modes](https://www.postgresql.org/docs/current/libpq-ssl.html#LIBPQ-SSL-PROTECTION) are supported and you are able to configure `sslmode`. The client is in `DISABLE` SSL mode by default.
-`ssl` parameter is kept as a mere shortcut for setting `sslmode`. `setSsl(true)` is equivalent to `setSslMode(REQUIRE)` and `setSsl(false)` is equivalent to `setSslMode(DISABLE)`.
+`ssl` parameter is kept as a mere shortcut for setting `sslmode`. `setSsl(true)` is equivalent to `setSslMode(VERIFY_CA)` and `setSsl(false)` is equivalent to `setSslMode(DISABLE)`.
 
 ```$lang
 {@link examples.Examples#ex10}

--- a/src/main/java/examples/Examples.java
+++ b/src/main/java/examples/Examples.java
@@ -669,7 +669,7 @@ public class Examples {
       .setDatabase("the-db")
       .setUser("user")
       .setPassword("secret")
-      .setSsl(true)
+      .setSslMode(SslMode.VERIFY_CA)
       .setPemTrustOptions(new PemTrustOptions().addCertPath("/path/to/cert.pem"));
 
     PgClient.connect(vertx, options, res -> {

--- a/src/main/java/io/reactiverse/pgclient/PgClient.java
+++ b/src/main/java/io/reactiverse/pgclient/PgClient.java
@@ -104,7 +104,7 @@ public interface PgClient {
     Context ctx = Vertx.currentContext();
     if (ctx != null) {
       PgConnectionFactory client = new PgConnectionFactory(ctx, false, options);
-      client.connect(ar -> {
+      client.create(ar -> {
         if (ar.succeeded()) {
           Connection conn = ar.result();
           PgConnectionImpl p = new PgConnectionImpl(ctx, conn);

--- a/src/main/java/io/reactiverse/pgclient/PgConnectOptions.java
+++ b/src/main/java/io/reactiverse/pgclient/PgConnectOptions.java
@@ -258,7 +258,7 @@ public class PgConnectOptions extends NetClientOptions {
   @Override
   public PgConnectOptions setSsl(boolean ssl) {
     if (ssl) {
-      setSslMode(SslMode.REQUIRE);
+      setSslMode(SslMode.VERIFY_CA);
     } else {
       setSslMode(SslMode.DISABLE);
     }

--- a/src/main/java/io/reactiverse/pgclient/PgConnectOptions.java
+++ b/src/main/java/io/reactiverse/pgclient/PgConnectOptions.java
@@ -79,6 +79,9 @@ public class PgConnectOptions extends NetClientOptions {
     if (getenv("PGPASSWORD") != null) {
       pgConnectOptions.setPassword(getenv("PGPASSWORD"));
     }
+    if (getenv("PGSSLMODE") != null) {
+      pgConnectOptions.setSslMode(SslMode.of(getenv("PGSSLMODE")));
+    }
     return pgConnectOptions;
   }
 
@@ -89,6 +92,7 @@ public class PgConnectOptions extends NetClientOptions {
   public static final String DEFAULT_PASSWORD = "pass";
   public static final boolean DEFAULT_CACHE_PREPARED_STATEMENTS = false;
   public static final int DEFAULT_PIPELINING_LIMIT = 256;
+  public static final SslMode DEFAULT_SSLMODE = SslMode.DISABLE;
 
   private String host;
   private int port;
@@ -97,6 +101,7 @@ public class PgConnectOptions extends NetClientOptions {
   private String password;
   private boolean cachePreparedStatements;
   private int pipeliningLimit;
+  private SslMode sslMode;
 
   public PgConnectOptions() {
     super();
@@ -118,6 +123,7 @@ public class PgConnectOptions extends NetClientOptions {
     password = other.password;
     pipeliningLimit = other.pipeliningLimit;
     cachePreparedStatements = other.cachePreparedStatements;
+    sslMode = other.sslMode;
   }
 
   public String getHost() {
@@ -186,6 +192,15 @@ public class PgConnectOptions extends NetClientOptions {
     return this;
   }
 
+  public SslMode getSslMode() {
+    return sslMode;
+  }
+
+  public PgConnectOptions setSslMode(SslMode sslmode) {
+    this.sslMode = sslmode;
+    return this;
+  }
+
   @Override
   public PgConnectOptions setSendBufferSize(int sendBufferSize) {
     return (PgConnectOptions)super.setSendBufferSize(sendBufferSize);
@@ -231,8 +246,15 @@ public class PgConnectOptions extends NetClientOptions {
     return (PgConnectOptions)super.setIdleTimeout(idleTimeout);
   }
 
+  @Deprecated
   @Override
   public PgConnectOptions setSsl(boolean ssl) {
+    // keep consistence with Vert.x NetClient behavior to avoid breaking changes, try setSslMode() instead.
+    if (ssl) {
+      setSslMode(SslMode.REQUIRE);
+    } else {
+      setSslMode(SslMode.DISABLE);
+    }
     return (PgConnectOptions)super.setSsl(ssl);
   }
 
@@ -397,6 +419,7 @@ public class PgConnectOptions extends NetClientOptions {
     password = DEFAULT_PASSWORD;
     cachePreparedStatements = DEFAULT_CACHE_PREPARED_STATEMENTS;
     pipeliningLimit = DEFAULT_PIPELINING_LIMIT;
+    sslMode = DEFAULT_SSLMODE;
   }
 
   @Override
@@ -421,6 +444,7 @@ public class PgConnectOptions extends NetClientOptions {
     if (!password.equals(that.password)) return false;
     if (cachePreparedStatements != that.cachePreparedStatements) return false;
     if (pipeliningLimit != that.pipeliningLimit) return false;
+    if (sslMode != that.sslMode) return false;
 
     return true;
   }
@@ -435,6 +459,7 @@ public class PgConnectOptions extends NetClientOptions {
     result = 31 * result + password.hashCode();
     result = 31 * result + (cachePreparedStatements ? 1 : 0);
     result = 31 * result + pipeliningLimit;
+    result = 31 * result + sslMode.hashCode();
     return result;
   }
 

--- a/src/main/java/io/reactiverse/pgclient/PgConnectOptions.java
+++ b/src/main/java/io/reactiverse/pgclient/PgConnectOptions.java
@@ -246,16 +246,14 @@ public class PgConnectOptions extends NetClientOptions {
     return (PgConnectOptions)super.setIdleTimeout(idleTimeout);
   }
 
-  @Deprecated
   @Override
   public PgConnectOptions setSsl(boolean ssl) {
-    // keep consistence with Vert.x NetClient behavior to avoid breaking changes, try setSslMode() instead.
     if (ssl) {
       setSslMode(SslMode.REQUIRE);
     } else {
       setSslMode(SslMode.DISABLE);
     }
-    return (PgConnectOptions)super.setSsl(ssl);
+    return this;
   }
 
   @Override

--- a/src/main/java/io/reactiverse/pgclient/PgConnectOptions.java
+++ b/src/main/java/io/reactiverse/pgclient/PgConnectOptions.java
@@ -192,10 +192,19 @@ public class PgConnectOptions extends NetClientOptions {
     return this;
   }
 
+  /**
+   * @return the value of current sslmode
+   */
   public SslMode getSslMode() {
     return sslMode;
   }
 
+  /**
+   * Set {@link SslMode} for the client, this option can be used to provide different levels of secure protection.
+   *
+   * @param sslmode the value of sslmode
+   * @return a reference to this, so the API can be used fluently
+   */
   public PgConnectOptions setSslMode(SslMode sslmode) {
     this.sslMode = sslmode;
     return this;

--- a/src/main/java/io/reactiverse/pgclient/PgPoolOptions.java
+++ b/src/main/java/io/reactiverse/pgclient/PgPoolOptions.java
@@ -205,7 +205,6 @@ public class PgPoolOptions extends PgConnectOptions {
     return (PgPoolOptions) super.setIdleTimeout(idleTimeout);
   }
 
-  @Deprecated
   @Override
   public PgPoolOptions setSsl(boolean ssl) {
     return (PgPoolOptions) super.setSsl(ssl);

--- a/src/main/java/io/reactiverse/pgclient/PgPoolOptions.java
+++ b/src/main/java/io/reactiverse/pgclient/PgPoolOptions.java
@@ -156,6 +156,11 @@ public class PgPoolOptions extends PgConnectOptions {
   }
 
   @Override
+  public PgPoolOptions setSslMode(SslMode sslmode) {
+    return (PgPoolOptions) super.setSslMode(sslmode);
+  }
+
+  @Override
   public PgPoolOptions setSendBufferSize(int sendBufferSize) {
     return (PgPoolOptions) super.setSendBufferSize(sendBufferSize);
   }
@@ -200,6 +205,7 @@ public class PgPoolOptions extends PgConnectOptions {
     return (PgPoolOptions) super.setIdleTimeout(idleTimeout);
   }
 
+  @Deprecated
   @Override
   public PgPoolOptions setSsl(boolean ssl) {
     return (PgPoolOptions) super.setSsl(ssl);

--- a/src/main/java/io/reactiverse/pgclient/SslMode.java
+++ b/src/main/java/io/reactiverse/pgclient/SslMode.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2018 Julien Viet
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package io.reactiverse.pgclient;
+
+/**
+ * The different values for the sslmode parameter provide different levels of protection.
+ * See more information in <a href="https://www.postgresql.org/docs/current/libpq-ssl.html#LIBPQ-SSL-PROTECTION">Protection Provided in Different Modes</a>.
+ */
+public enum SslMode {
+
+  /**
+   * only try a non-SSL connection.
+   */
+  DISABLE("disable"),
+
+  /**
+   * first try a non-SSL connection; if that fails, try an SSL connection.
+   */
+  ALLOW("allow"),
+
+  /**
+   * first try an SSL connection; if that fails, try a non-SSL connection.
+   */
+  PREFER("prefer"),
+
+  /**
+   * only try an SSL connection. If a root CA file is present, verify the certificate in the same way as if verify-ca was specified.
+   */
+  REQUIRE("require"),
+
+  /**
+   * only try an SSL connection, and verify that the server certificate is issued by a trusted certificate authority (CA).
+   */
+  VERIFY_CA("verify-ca"),
+
+  /**
+   * only try an SSL connection, verify that the server certificate is issued by a trusted CA and that the requested server host name matches that in the certificate.
+   */
+  VERIFY_FULL("verify-full");
+
+  public static final SslMode[] VALUES = SslMode.values();
+
+  public final String value;
+
+  SslMode(String value) {
+    this.value = value;
+  }
+
+  public static SslMode of(String value) {
+    for (SslMode sslMode : VALUES) {
+      if (sslMode.value.equalsIgnoreCase(value)) {
+        return sslMode;
+      }
+    }
+
+    throw new IllegalArgumentException("Could not find an appropriate SSL mode for the value [" + value + "].");
+  }
+}

--- a/src/main/java/io/reactiverse/pgclient/impl/PgConnectionFactory.java
+++ b/src/main/java/io/reactiverse/pgclient/impl/PgConnectionFactory.java
@@ -17,6 +17,7 @@
 
 package io.reactiverse.pgclient.impl;
 
+import io.netty.handler.codec.DecoderException;
 import io.reactiverse.pgclient.PgConnectOptions;
 import io.reactiverse.pgclient.SslMode;
 import io.vertx.core.*;
@@ -89,7 +90,88 @@ public class PgConnectionFactory {
     client.close();
   }
 
-  public void connect(Handler<? super CommandResponse<Connection>> completionHandler) {
+  public void create(Handler<? super CommandResponse<Connection>> completionHandler) {
+    connect(ar -> {
+      if (ar.succeeded()) {
+        SocketConnection conn = ar.result();
+        conn.initializeCodec();
+        conn.sendStartupMessage(username, password, database, completionHandler);
+      } else {
+        completionHandler.handle(CommandResponse.failure(ar.cause()));
+      }
+    });
+  }
+
+  public void connect(Handler<AsyncResult<SocketConnection>> handler) {
+    switch (sslMode) {
+      case DISABLE:
+        initiateConnection(false, handler);
+        break;
+      case ALLOW:
+        initiateConnection(false, ar -> {
+          if (ar.succeeded()) {
+            handler.handle(Future.succeededFuture(ar.result()));
+          } else {
+            initiateConnection(true, handler);
+          }
+        });
+        break;
+      case PREFER:
+        initiateConnection(true, ar -> {
+          if (ar.succeeded()) {
+            handler.handle(Future.succeededFuture(ar.result()));
+          } else {
+            initiateConnection(false, handler);
+          }
+        });
+        break;
+      case VERIFY_FULL:
+        if (hostnameVerificationAlgorithm == null || hostnameVerificationAlgorithm.isEmpty()) {
+          handler.handle(Future.failedFuture(new IllegalArgumentException("Host verification algorithm must be specified under verify-full sslmode")));
+          return;
+        }
+      case VERIFY_CA:
+        if (trustOptions == null) {
+          handler.handle(Future.failedFuture(new IllegalArgumentException("Trust options must be specified under verify-full or verify-ca sslmode")));
+          return;
+        }
+      case REQUIRE:
+        initiateConnection(true, handler);
+        break;
+      default:
+        throw new IllegalArgumentException("Unsupported SSL mode");
+    }
+  }
+
+  private void initiateConnection(boolean ssl, Handler<AsyncResult<SocketConnection>> handler) {
+    doConnect(ar -> {
+      if (ar.succeeded()) {
+        SocketConnection conn = ar.result();
+
+        if (ssl && !isUsingDomainSocket) {
+          // upgrade connection to SSL if needed
+          conn.upgradeToSSLConnection(ar2 -> {
+            if (ar2.succeeded()) {
+              handler.handle(Future.succeededFuture(conn));
+            } else {
+              Throwable cause = ar2.cause();
+              if (cause instanceof DecoderException) {
+                DecoderException err = (DecoderException) cause;
+                cause = err.getCause();
+              }
+              handler.handle(Future.failedFuture(cause));
+            }
+          });
+        } else {
+          handler.handle(Future.succeededFuture(conn));
+        }
+      } else {
+        handler.handle(Future.failedFuture(ar.cause()));
+      }
+    });
+  }
+
+  private void doConnect(Handler<AsyncResult<SocketConnection>> handler) {
     if (Vertx.currentContext() != ctx) {
       throw new IllegalStateException();
     }
@@ -100,75 +182,25 @@ public class PgConnectionFactory {
       socketAddress = SocketAddress.domainSocketAddress(host + "/.s.PGSQL." + port);
     }
 
-    doConnect(socketAddress, sslMode, completionHandler);
-  }
-
-  private void doConnect(SocketAddress socketAddress, SslMode sslMode, Handler<? super CommandResponse<Connection>> completionHandler) {
-    switch (sslMode) {
-      case DISABLE:
-        doConnect(socketAddress, false, completionHandler);
-        break;
-      case ALLOW:
-        doConnect(socketAddress, false, ar -> {
-          if (ar.succeeded()) {
-            completionHandler.handle(ar);
-          } else {
-            doConnect(socketAddress, true, completionHandler);
-          }
-        });
-        break;
-      case PREFER:
-        doConnect(socketAddress, true, ar -> {
-          if (ar.succeeded()) {
-            completionHandler.handle(ar);
-          } else {
-            doConnect(socketAddress, false, completionHandler);
-          }
-        });
-        break;
-      case VERIFY_FULL:
-        if (hostnameVerificationAlgorithm == null || hostnameVerificationAlgorithm.isEmpty()) {
-          completionHandler.handle(CommandResponse.failure(new IllegalArgumentException("Host verification algorithm must be specified under verify-full sslmode")));
-          return;
-        }
-      case VERIFY_CA:
-        if (trustOptions == null) {
-          completionHandler.handle(CommandResponse.failure(new IllegalArgumentException("Trust options must be specified under verify-full or verify-ca sslmode")));
-          return;
-        }
-      case REQUIRE:
-        doConnect(socketAddress, true, completionHandler);
-        break;
-      default:
-        throw new IllegalArgumentException("Unsupported SSL mode");
-    }
-  }
-
-  private void doConnect(SocketAddress socketAddress, boolean ssl, Handler<? super CommandResponse<Connection>> completionHandler) {
-    Future<NetSocket> fut = Future.<NetSocket>future().setHandler(ar -> {
+    Future<NetSocket> future = Future.<NetSocket>future().setHandler(ar -> {
       if (ar.succeeded()) {
         NetSocketInternal socket = (NetSocketInternal) ar.result();
-        SocketConnection conn = newSocketConnection(socket, ssl, isUsingDomainSocket);
-        conn.initiateProtocolOrSsl(username, password, database, completionHandler);
+        SocketConnection conn = newSocketConnection(socket);
+        handler.handle(Future.succeededFuture(conn));
       } else {
-        completionHandler.handle(CommandResponse.failure(ar.cause()));
+        handler.handle(Future.failedFuture(ar.cause()));
       }
     });
 
     try {
-      client.connect(socketAddress, null, fut);
+      client.connect(socketAddress, null, future);
     } catch (Exception e) {
       // Client is closed
-      fut.fail(e);
+      future.fail(e);
     }
   }
 
-  private SocketConnection newSocketConnection(NetSocketInternal socket, boolean ssl, boolean isUsingDomainSocket) {
-    return new SocketConnection(socket,
-      ssl,
-      isUsingDomainSocket,
-      this.cachePreparedStatements,
-      this.pipeliningLimit,
-      this.ctx);
+  private SocketConnection newSocketConnection(NetSocketInternal socket) {
+    return new SocketConnection(socket, cachePreparedStatements, pipeliningLimit, ctx);
   }
 }

--- a/src/main/java/io/reactiverse/pgclient/impl/PgConnectionUriParser.java
+++ b/src/main/java/io/reactiverse/pgclient/impl/PgConnectionUriParser.java
@@ -16,6 +16,7 @@
  */
 package io.reactiverse.pgclient.impl;
 
+import io.reactiverse.pgclient.SslMode;
 import io.vertx.core.json.JsonObject;
 
 import java.io.UnsupportedEncodingException;
@@ -161,6 +162,9 @@ public class PgConnectionUriParser {
             break;
           case "dbname":
             configuration.put("database", value);
+            break;
+          case "sslmode":
+            configuration.put("sslMode", SslMode.of(value));
             break;
           default:
             configuration.put(key, value);

--- a/src/main/java/io/reactiverse/pgclient/impl/PgPoolImpl.java
+++ b/src/main/java/io/reactiverse/pgclient/impl/PgPoolImpl.java
@@ -20,8 +20,6 @@ package io.reactiverse.pgclient.impl;
 import io.reactiverse.pgclient.*;
 import io.vertx.core.*;
 
-import java.util.function.BiConsumer;
-
 /**
  * Todo :
  *
@@ -48,7 +46,7 @@ public class PgPoolImpl extends PgClientBase<PgPoolImpl> implements PgPool {
     }
     this.context = vertx.getOrCreateContext();
     this.factory = new PgConnectionFactory(context, Vertx.currentContext() != null, options);
-    this.pool = new ConnectionPool(factory::connect, maxSize, options.getMaxWaitQueueSize());
+    this.pool = new ConnectionPool(factory::create, maxSize, options.getMaxWaitQueueSize());
     this.closeVertx = closeVertx;
   }
 

--- a/src/main/java/io/reactiverse/pgclient/impl/codec/decoder/InitiateSslHandler.java
+++ b/src/main/java/io/reactiverse/pgclient/impl/codec/decoder/InitiateSslHandler.java
@@ -27,8 +27,6 @@ import io.reactiverse.pgclient.impl.codec.decoder.type.MessageType;
 import io.vertx.core.Future;
 import io.vertx.core.VertxException;
 
-import java.nio.channels.ClosedChannelException;
-
 public class InitiateSslHandler extends ChannelInboundHandlerAdapter {
 
   private static final int code = 80877103;
@@ -59,7 +57,7 @@ public class InitiateSslHandler extends ChannelInboundHandlerAdapter {
     byteBuf.release();
     switch (b) {
       case MessageType.SSL_YES: {
-        conn.upgradeToSSL(v -> {
+        conn.socket().upgradeToSsl(v -> {
           ctx.pipeline().remove(this);
           upgradeFuture.complete();
         });

--- a/src/main/java/io/reactiverse/pgclient/impl/codec/decoder/InitiateSslHandler.java
+++ b/src/main/java/io/reactiverse/pgclient/impl/codec/decoder/InitiateSslHandler.java
@@ -81,7 +81,9 @@ public class InitiateSslHandler extends ChannelInboundHandlerAdapter {
       DecoderException err = (DecoderException) cause;
       cause = err.getCause();
     }
-    upgradeFuture.fail(cause);
+    if (!upgradeFuture.isComplete()) {
+      upgradeFuture.fail(cause);
+    }
   }
 
   @Override

--- a/src/main/java/io/reactiverse/pgclient/impl/codec/decoder/InitiateSslHandler.java
+++ b/src/main/java/io/reactiverse/pgclient/impl/codec/decoder/InitiateSslHandler.java
@@ -79,17 +79,13 @@ public class InitiateSslHandler extends ChannelInboundHandlerAdapter {
       DecoderException err = (DecoderException) cause;
       cause = err.getCause();
     }
-    if (!upgradeFuture.isComplete()) {
-      upgradeFuture.fail(cause);
-    }
+    upgradeFuture.tryFail(cause);
   }
 
   @Override
   public void channelInactive(ChannelHandlerContext ctx) throws Exception {
     super.channelInactive(ctx);
     // Work around for https://github.com/eclipse-vertx/vert.x/issues/2748
-    if (!upgradeFuture.isComplete()) {
-      upgradeFuture.fail(new VertxException("SSL handshake failed", true));
-    }
+    upgradeFuture.tryFail(new VertxException("SSL handshake failed", true));
   }
 }

--- a/src/main/kotlin/io/reactiverse/kotlin/pgclient/PgConnectOptions.kt
+++ b/src/main/kotlin/io/reactiverse/kotlin/pgclient/PgConnectOptions.kt
@@ -48,7 +48,7 @@ import java.util.concurrent.TimeUnit
  * @param sendBufferSize 
  * @param soLinger 
  * @param ssl 
- * @param sslMode 
+ * @param sslMode  Set [io.reactiverse.pgclient.SslMode] for the client, this option can be used to provide different levels of secure protection.
  * @param tcpCork 
  * @param tcpFastOpen 
  * @param tcpKeepAlive 

--- a/src/main/kotlin/io/reactiverse/kotlin/pgclient/PgConnectOptions.kt
+++ b/src/main/kotlin/io/reactiverse/kotlin/pgclient/PgConnectOptions.kt
@@ -1,6 +1,7 @@
 package io.reactiverse.kotlin.pgclient
 
 import io.reactiverse.pgclient.PgConnectOptions
+import io.reactiverse.pgclient.SslMode
 import io.vertx.core.net.JdkSSLEngineOptions
 import io.vertx.core.net.JksOptions
 import io.vertx.core.net.OpenSSLEngineOptions
@@ -47,6 +48,7 @@ import java.util.concurrent.TimeUnit
  * @param sendBufferSize 
  * @param soLinger 
  * @param ssl 
+ * @param sslMode 
  * @param tcpCork 
  * @param tcpFastOpen 
  * @param tcpKeepAlive 
@@ -96,6 +98,7 @@ fun PgConnectOptions(
   sendBufferSize: Int? = null,
   soLinger: Int? = null,
   ssl: Boolean? = null,
+  sslMode: SslMode? = null,
   tcpCork: Boolean? = null,
   tcpFastOpen: Boolean? = null,
   tcpKeepAlive: Boolean? = null,
@@ -212,6 +215,9 @@ fun PgConnectOptions(
   }
   if (ssl != null) {
     this.setSsl(ssl)
+  }
+  if (sslMode != null) {
+    this.setSslMode(sslMode)
   }
   if (tcpCork != null) {
     this.setTcpCork(tcpCork)

--- a/src/main/kotlin/io/reactiverse/kotlin/pgclient/PgPoolOptions.kt
+++ b/src/main/kotlin/io/reactiverse/kotlin/pgclient/PgPoolOptions.kt
@@ -51,7 +51,7 @@ import java.util.concurrent.TimeUnit
  * @param sendBufferSize 
  * @param soLinger 
  * @param ssl 
- * @param sslMode 
+ * @param sslMode  Set [io.reactiverse.pgclient.SslMode] for the client, this option can be used to provide different levels of secure protection.
  * @param tcpCork 
  * @param tcpFastOpen 
  * @param tcpKeepAlive 

--- a/src/main/kotlin/io/reactiverse/kotlin/pgclient/PgPoolOptions.kt
+++ b/src/main/kotlin/io/reactiverse/kotlin/pgclient/PgPoolOptions.kt
@@ -1,6 +1,7 @@
 package io.reactiverse.kotlin.pgclient
 
 import io.reactiverse.pgclient.PgPoolOptions
+import io.reactiverse.pgclient.SslMode
 import io.vertx.core.net.JdkSSLEngineOptions
 import io.vertx.core.net.JksOptions
 import io.vertx.core.net.OpenSSLEngineOptions
@@ -50,6 +51,7 @@ import java.util.concurrent.TimeUnit
  * @param sendBufferSize 
  * @param soLinger 
  * @param ssl 
+ * @param sslMode 
  * @param tcpCork 
  * @param tcpFastOpen 
  * @param tcpKeepAlive 
@@ -101,6 +103,7 @@ fun PgPoolOptions(
   sendBufferSize: Int? = null,
   soLinger: Int? = null,
   ssl: Boolean? = null,
+  sslMode: SslMode? = null,
   tcpCork: Boolean? = null,
   tcpFastOpen: Boolean? = null,
   tcpKeepAlive: Boolean? = null,
@@ -223,6 +226,9 @@ fun PgPoolOptions(
   }
   if (ssl != null) {
     this.setSsl(ssl)
+  }
+  if (sslMode != null) {
+    this.setSslMode(sslMode)
   }
   if (tcpCork != null) {
     this.setTcpCork(tcpCork)

--- a/src/test/java/io/reactiverse/pgclient/PgClientTestBase.java
+++ b/src/test/java/io/reactiverse/pgclient/PgClientTestBase.java
@@ -101,7 +101,7 @@ public abstract class PgClientTestBase<C extends PgClient> extends PgTestBase {
   @Test
   public void testConnectNonSSLServer(TestContext ctx) {
     Async async = ctx.async();
-    options.setSsl(true).setTrustAll(true);
+    options.setSslMode(SslMode.REQUIRE).setTrustAll(true);
     connector.accept(ctx.asyncAssertFailure(err -> {
       ctx.assertEquals("Postgres Server does not handle SSL connection", err.getMessage());
       async.complete();

--- a/src/test/java/io/reactiverse/pgclient/PgConnectOptionsProviderTest.java
+++ b/src/test/java/io/reactiverse/pgclient/PgConnectOptionsProviderTest.java
@@ -137,6 +137,19 @@ public class PgConnectOptionsProviderTest {
     assertEquals(expectedConfiguration, actualConfiguration);
   }
 
+  @Test
+  public void testValidUri10() {
+    connectionUri = "postgresql://user@myhost?sslmode=require";
+    actualConfiguration = PgConnectOptions.fromUri(connectionUri);
+
+    expectedConfiguration = new PgConnectOptions()
+      .setHost("myhost")
+      .setUser("user")
+      .setSslMode(SslMode.REQUIRE);
+
+    assertEquals(expectedConfiguration, actualConfiguration);
+  }
+
   @Test(expected = IllegalArgumentException.class)
   public void testInvalidUri1() {
     connectionUri = "postgrsql://username";

--- a/src/test/java/io/reactiverse/pgclient/PgConnectionUriParserTest.java
+++ b/src/test/java/io/reactiverse/pgclient/PgConnectionUriParserTest.java
@@ -277,6 +277,20 @@ public class PgConnectionUriParserTest {
     assertEquals(expectedParsedResult, actualParsedResult);
   }
 
+  @Test
+  public void testParsingParameterSslMode() {
+    uri = "postgresql://?host=localhost&port=1234&sslmode=require";
+
+    actualParsedResult = parse(uri);
+
+    expectedParsedResult = new JsonObject()
+      .put("host", "localhost")
+      .put("port", 1234)
+      .put("sslMode", "REQUIRE");
+
+    assertEquals(expectedParsedResult, actualParsedResult);
+  }
+
   @Test(expected = IllegalArgumentException.class)
   public void testParsingInvalidUri1() {
     uri = "postgresql://us@er@@";
@@ -316,6 +330,12 @@ public class PgConnectionUriParserTest {
   @Test(expected = IllegalArgumentException.class)
   public void testParsingInvalidUri7() {
     uri = "postgresql://@@/dbname?host";
+    actualParsedResult = parse(uri);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testParsingInvalidSslmode() {
+    uri = "postgresql://?sslmode=invalidsslmode";
     actualParsedResult = parse(uri);
   }
 }

--- a/src/test/java/io/reactiverse/pgclient/PgTestBase.java
+++ b/src/test/java/io/reactiverse/pgclient/PgTestBase.java
@@ -168,6 +168,7 @@ public abstract class PgTestBase {
     }
   }
 
+  // ssl=on just enables the possibility of using SSL which does not force clients to use SSL
   private static IRuntimeConfig useSSLRuntimeConfig(IRuntimeConfig config) throws Exception {
     File sslKey = getTestResource("server.key");
     Files.setPosixFilePermissions(sslKey.toPath(), Collections.singleton(PosixFilePermission.OWNER_READ));

--- a/src/test/java/io/reactiverse/pgclient/UnixDomainSocketTest.java
+++ b/src/test/java/io/reactiverse/pgclient/UnixDomainSocketTest.java
@@ -24,6 +24,7 @@ import io.vertx.ext.unit.junit.VertxUnitRunner;
 import org.junit.*;
 import org.junit.runner.RunWith;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assume.assumeTrue;
 
 @RunWith(VertxUnitRunner.class)
@@ -94,5 +95,15 @@ public class UnixDomainSocketTest {
     } finally {
       vertx.close();
     }
+  }
+
+  @Test
+  public void testIgnoreSslMode(TestContext context) {
+    assumeTrue(options.isUsingDomainSocket());
+    client = PgClient.pool(new PgPoolOptions(options).setSslMode(SslMode.REQUIRE));
+    client.getConnection(context.asyncAssertSuccess(pgConnection -> {
+      assertFalse(pgConnection.isSSL());
+      pgConnection.close();
+    }));
   }
 }

--- a/src/test/java/io/reactiverse/pgclient/it/EnvTest.java
+++ b/src/test/java/io/reactiverse/pgclient/it/EnvTest.java
@@ -17,6 +17,7 @@
 package io.reactiverse.pgclient.it;
 
 import io.reactiverse.pgclient.PgConnectOptions;
+import io.reactiverse.pgclient.SslMode;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -30,5 +31,6 @@ public class EnvTest {
     assertEquals("test_database", options.getDatabase());
     assertEquals("test_user", options.getUser());
     assertEquals("test_password", options.getPassword());
+    assertEquals(SslMode.REQUIRE, options.getSslMode());
   }
 }


### PR DESCRIPTION
This PR is to fix #207.

Changes:
- add support for **sslmode**
- **ssl** parameter is now deprecated and **sslmode** should be used instead.
 Client is in `DISABLE` mode by default, `setSsl(true)` is equivalent to `setSslMode(REQUIRE)` and `setSsl(false)` is equivalent to `setSslMode(DISABLE)` so that we can avoid break changes.
- refactor PgConnectionFactory and SocketConnection class