### PR TITLE
Remove @GenIgnore or use permitted-type in Tuple/Row methods when pos…

### DIFF
--- a/src/main/java/io/reactiverse/pgclient/Row.java
+++ b/src/main/java/io/reactiverse/pgclient/Row.java
@@ -131,7 +131,7 @@ public interface Row extends Tuple {
    * @param name the column
    * @return the value or {@code null}
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   Temporal getTemporal(String name);
 
   /**
@@ -140,7 +140,7 @@ public interface Row extends Tuple {
    * @param name the column
    * @return the value or {@code null}
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   LocalDate getLocalDate(String name);
 
   /**
@@ -149,7 +149,7 @@ public interface Row extends Tuple {
    * @param name the column
    * @return the value or {@code null}
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   LocalTime getLocalTime(String name);
 
   /**
@@ -158,7 +158,7 @@ public interface Row extends Tuple {
    * @param name the column
    * @return the value or {@code null}
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   LocalDateTime getLocalDateTime(String name);
 
   /**
@@ -167,7 +167,7 @@ public interface Row extends Tuple {
    * @param name the column
    * @return the value or {@code null}
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   OffsetTime getOffsetTime(String name);
 
   /**
@@ -176,7 +176,7 @@ public interface Row extends Tuple {
    * @param name the column
    * @return the value or {@code null}
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   OffsetDateTime getOffsetDateTime(String name);
 
   /**
@@ -185,7 +185,7 @@ public interface Row extends Tuple {
    * @param name the column
    * @return the value or {@code null}
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   UUID getUUID(String name);
 
   /**
@@ -194,7 +194,7 @@ public interface Row extends Tuple {
    * @param name the column
    * @return the value or {@code null}
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   BigDecimal getBigDecimal(String name);
 
   /**
@@ -203,7 +203,7 @@ public interface Row extends Tuple {
    * @param name the column
    * @return the value or {@code null}
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   Numeric getNumeric(String name);
 
   /**
@@ -212,7 +212,6 @@ public interface Row extends Tuple {
    * @param name the column
    * @return the value or {@code null}
    */
-  @GenIgnore
   Point getPoint(String name);
 
   /**
@@ -221,7 +220,6 @@ public interface Row extends Tuple {
    * @param name the column
    * @return the value or {@code null}
    */
-  @GenIgnore
   Line getLine(String name);
 
   /**
@@ -230,7 +228,6 @@ public interface Row extends Tuple {
    * @param name the column
    * @return the value or {@code null}
    */
-  @GenIgnore
   LineSegment getLineSegment(String name);
 
   /**
@@ -239,7 +236,6 @@ public interface Row extends Tuple {
    * @param name the column
    * @return the value or {@code null}
    */
-  @GenIgnore
   Box getBox(String name);
 
   /**
@@ -248,7 +244,6 @@ public interface Row extends Tuple {
    * @param name the column
    * @return the value or {@code null}
    */
-  @GenIgnore
   Path getPath(String name);
 
   /**
@@ -257,7 +252,6 @@ public interface Row extends Tuple {
    * @param name the column
    * @return the value or {@code null}
    */
-  @GenIgnore
   Polygon getPolygon(String name);
 
   /**
@@ -266,7 +260,6 @@ public interface Row extends Tuple {
    * @param name the column
    * @return the value or {@code null}
    */
-  @GenIgnore
   Circle getCircle(String name);
 
   /**
@@ -275,7 +268,6 @@ public interface Row extends Tuple {
    * @param name the column
    * @return the value or {@code null}
    */
-  @GenIgnore
   Interval getInterval(String name);
 
   /**
@@ -284,7 +276,7 @@ public interface Row extends Tuple {
    * @param name the column
    * @return the value or {@code null}
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   Integer[] getIntegerArray(String name);
 
   /**
@@ -293,7 +285,7 @@ public interface Row extends Tuple {
    * @param name the column
    * @return the value or {@code null}
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   Boolean[] getBooleanArray(String name);
 
   /**
@@ -302,7 +294,7 @@ public interface Row extends Tuple {
    * @param name the column
    * @return the value or {@code null}
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   Short[] getShortArray(String name);
 
   /**
@@ -311,7 +303,7 @@ public interface Row extends Tuple {
    * @param name the column
    * @return the value or {@code null}
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   Long[] getLongArray(String name);
 
   /**
@@ -320,7 +312,7 @@ public interface Row extends Tuple {
    * @param name the column
    * @return the value or {@code null}
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   Float[] getFloatArray(String name);
 
   /**
@@ -329,7 +321,7 @@ public interface Row extends Tuple {
    * @param name the column
    * @return the value or {@code null}
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   Double[] getDoubleArray(String name);
 
   /**
@@ -338,7 +330,7 @@ public interface Row extends Tuple {
    * @param name the column
    * @return the value or {@code null}
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   String[] getStringArray(String name);
 
   /**
@@ -347,7 +339,7 @@ public interface Row extends Tuple {
    * @param name the column
    * @return the value or {@code null}
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   LocalDate[] getLocalDateArray(String name);
 
   /**
@@ -356,7 +348,7 @@ public interface Row extends Tuple {
    * @param name the column
    * @return the value or {@code null}
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   LocalTime[] getLocalTimeArray(String name);
 
   /**
@@ -365,7 +357,7 @@ public interface Row extends Tuple {
    * @param name the column
    * @return the value or {@code null}
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   OffsetTime[] getOffsetTimeArray(String name);
 
   /**
@@ -374,7 +366,7 @@ public interface Row extends Tuple {
    * @param name the column
    * @return the value or {@code null}
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   LocalDateTime[] getLocalDateTimeArray(String name);
 
   /**
@@ -383,7 +375,7 @@ public interface Row extends Tuple {
    * @param name the column
    * @return the value or {@code null}
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   OffsetDateTime[] getOffsetDateTimeArray(String name);
 
   /**
@@ -401,7 +393,7 @@ public interface Row extends Tuple {
    * @param name the column
    * @return the value or {@code null}
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   UUID[] getUUIDArray(String name);
 
   /**
@@ -419,7 +411,7 @@ public interface Row extends Tuple {
    * @param name the column
    * @return the value or {@code null}
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   Numeric[] getNumericArray(String name);
 
   /**
@@ -428,7 +420,7 @@ public interface Row extends Tuple {
    * @param name the column
    * @return the value or {@code null}
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   Point[] getPointArray(String name);
 
   /**
@@ -437,7 +429,7 @@ public interface Row extends Tuple {
    * @param name the column
    * @return the value or {@code null}
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   Line[] getLineArray(String name);
 
   /**
@@ -446,7 +438,7 @@ public interface Row extends Tuple {
    * @param name the column
    * @return the value or {@code null}
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   LineSegment[] getLineSegmentArray(String name);
 
   /**
@@ -455,7 +447,7 @@ public interface Row extends Tuple {
    * @param name the column
    * @return the value or {@code null}
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   Box[] getBoxArray(String name);
 
   /**
@@ -464,7 +456,7 @@ public interface Row extends Tuple {
    * @param name the column
    * @return the value or {@code null}
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   Path[] getPathArray(String name);
 
   /**
@@ -473,7 +465,7 @@ public interface Row extends Tuple {
    * @param name the column
    * @return the value or {@code null}
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   Polygon[] getPolygonArray(String name);
 
   /**
@@ -482,7 +474,7 @@ public interface Row extends Tuple {
    * @param name the column
    * @return the value or {@code null}
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   Circle[] getCircleArray(String name);
 
   /**
@@ -491,6 +483,6 @@ public interface Row extends Tuple {
    * @param name the column
    * @return the value or {@code null}
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   Interval[] getIntervalArray(String name);
 }

--- a/src/main/java/io/reactiverse/pgclient/Tuple.java
+++ b/src/main/java/io/reactiverse/pgclient/Tuple.java
@@ -248,7 +248,7 @@ public interface Tuple {
    * @param pos the position
    * @return the value or {@code null}
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   Temporal getTemporal(int pos);
 
   /**
@@ -257,7 +257,7 @@ public interface Tuple {
    * @param pos the position
    * @return the value or {@code null}
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   LocalDate getLocalDate(int pos);
 
   /**
@@ -266,7 +266,7 @@ public interface Tuple {
    * @param pos the position
    * @return the value or {@code null}
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   LocalTime getLocalTime(int pos);
 
   /**
@@ -275,7 +275,7 @@ public interface Tuple {
    * @param pos the position
    * @return the value or {@code null}
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   LocalDateTime getLocalDateTime(int pos);
 
   /**
@@ -284,7 +284,7 @@ public interface Tuple {
    * @param pos the position
    * @return the value or {@code null}
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   OffsetTime getOffsetTime(int pos);
 
   /**
@@ -293,7 +293,7 @@ public interface Tuple {
    * @param pos the position
    * @return the value or {@code null}
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   OffsetDateTime getOffsetDateTime(int pos);
 
   /**
@@ -302,7 +302,7 @@ public interface Tuple {
    * @param pos the position
    * @return the value or {@code null}
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   UUID getUUID(int pos);
 
   /**
@@ -311,7 +311,7 @@ public interface Tuple {
    * @param pos the position
    * @return the value or {@code null}
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   BigDecimal getBigDecimal(int pos);
 
   /**
@@ -320,7 +320,7 @@ public interface Tuple {
    * @param pos the position
    * @return the value or {@code null}
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   Integer[] getIntegerArray(int pos);
 
   /**
@@ -329,7 +329,7 @@ public interface Tuple {
    * @param pos the position
    * @return the value or {@code null}
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   Boolean[] getBooleanArray(int pos);
 
   /**
@@ -338,7 +338,7 @@ public interface Tuple {
    * @param pos the position
    * @return the value or {@code null}
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   Short[] getShortArray(int pos);
 
   /**
@@ -347,7 +347,7 @@ public interface Tuple {
    * @param pos the position
    * @return the value or {@code null}
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   Long[] getLongArray(int pos);
 
   /**
@@ -356,7 +356,7 @@ public interface Tuple {
    * @param pos the position
    * @return the value or {@code null}
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   Float[] getFloatArray(int pos);
 
   /**
@@ -365,7 +365,7 @@ public interface Tuple {
    * @param pos the position
    * @return the value or {@code null}
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   Double[] getDoubleArray(int pos);
 
   /**
@@ -374,7 +374,7 @@ public interface Tuple {
    * @param pos the position
    * @return the value or {@code null}
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   String[] getStringArray(int pos);
 
   /**
@@ -383,7 +383,7 @@ public interface Tuple {
    * @param pos the position
    * @return the value or {@code null}
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   LocalDate[] getLocalDateArray(int pos);
 
   /**
@@ -392,7 +392,7 @@ public interface Tuple {
    * @param pos the position
    * @return the value or {@code null}
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   LocalTime[] getLocalTimeArray(int pos);
 
   /**
@@ -401,7 +401,7 @@ public interface Tuple {
    * @param pos the position
    * @return the value or {@code null}
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   OffsetTime[] getOffsetTimeArray(int pos);
 
   /**
@@ -410,7 +410,7 @@ public interface Tuple {
    * @param pos the position
    * @return the value or {@code null}
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   LocalDateTime[] getLocalDateTimeArray(int pos);
 
   /**
@@ -419,7 +419,7 @@ public interface Tuple {
    * @param pos the position
    * @return the value or {@code null}
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   OffsetDateTime[] getOffsetDateTimeArray(int pos);
 
   /**
@@ -437,7 +437,7 @@ public interface Tuple {
    * @param pos the column
    * @return the value or {@code null}
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   UUID[] getUUIDArray(int pos);
 
   /**
@@ -455,7 +455,7 @@ public interface Tuple {
    * @param pos the column
    * @return the value or {@code null}
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   Numeric[] getNumericArray(int pos);
 
   /**
@@ -464,7 +464,7 @@ public interface Tuple {
    * @param pos the column
    * @return the value or {@code null}
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   Point[] getPointArray(int pos);
 
   /**
@@ -473,7 +473,7 @@ public interface Tuple {
    * @param pos the column
    * @return the value or {@code null}
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   Line[] getLineArray(int pos);
 
   /**
@@ -482,7 +482,7 @@ public interface Tuple {
    * @param pos the column
    * @return the value or {@code null}
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   LineSegment[] getLineSegmentArray(int pos);
 
   /**
@@ -491,7 +491,7 @@ public interface Tuple {
    * @param pos the column
    * @return the value or {@code null}
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   Box[] getBoxArray(int pos);
 
   /**
@@ -500,7 +500,7 @@ public interface Tuple {
    * @param pos the column
    * @return the value or {@code null}
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   Path[] getPathArray(int pos);
 
   /**
@@ -509,7 +509,7 @@ public interface Tuple {
    * @param pos the column
    * @return the value or {@code null}
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   Polygon[] getPolygonArray(int pos);
 
   /**
@@ -518,7 +518,7 @@ public interface Tuple {
    * @param pos the column
    * @return the value or {@code null}
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   Circle[] getCircleArray(int pos);
 
   /**
@@ -527,7 +527,7 @@ public interface Tuple {
    * @param pos the column
    * @return the value or {@code null}
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   Interval[] getIntervalArray(int pos);
 
   /**
@@ -536,7 +536,7 @@ public interface Tuple {
    * @param pos the position
    * @return the value or {@code null}
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   Numeric getNumeric(int pos);
 
   /**
@@ -545,7 +545,6 @@ public interface Tuple {
    * @param pos the position
    * @return the value or {@code null}
    */
-  @GenIgnore
   Point getPoint(int pos);
 
   /**
@@ -554,7 +553,6 @@ public interface Tuple {
    * @param pos the position
    * @return the value or {@code null}
    */
-  @GenIgnore
   Line getLine(int pos);
 
   /**
@@ -563,7 +561,6 @@ public interface Tuple {
    * @param pos the position
    * @return the value or {@code null}
    */
-  @GenIgnore
   LineSegment getLineSegment(int pos);
 
   /**
@@ -572,7 +569,6 @@ public interface Tuple {
    * @param pos the position
    * @return the value or {@code null}
    */
-  @GenIgnore
   Box getBox(int pos);
 
   /**
@@ -581,7 +577,6 @@ public interface Tuple {
    * @param pos the position
    * @return the value or {@code null}
    */
-  @GenIgnore
   Path getPath(int pos);
 
   /**
@@ -590,7 +585,6 @@ public interface Tuple {
    * @param pos the position
    * @return the value or {@code null}
    */
-  @GenIgnore
   Polygon getPolygon(int pos);
 
   /**
@@ -599,7 +593,6 @@ public interface Tuple {
    * @param pos the position
    * @return the value or {@code null}
    */
-  @GenIgnore
   Circle getCircle(int pos);
 
   /**
@@ -608,7 +601,6 @@ public interface Tuple {
    * @param pos the position
    * @return the value or {@code null}
    */
-  @GenIgnore
   Interval getInterval(int pos);
 
   /**
@@ -715,7 +707,7 @@ public interface Tuple {
    * @param value the value
    * @return a reference to this, so the API can be used fluently
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   Tuple addTemporal(Temporal value);
 
   /**
@@ -724,7 +716,7 @@ public interface Tuple {
    * @param value the value
    * @return a reference to this, so the API can be used fluently
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   Tuple addLocalDate(LocalDate value);
 
   /**
@@ -733,7 +725,7 @@ public interface Tuple {
    * @param value the value
    * @return a reference to this, so the API can be used fluently
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   Tuple addLocalTime(LocalTime value);
 
   /**
@@ -742,7 +734,7 @@ public interface Tuple {
    * @param value the value
    * @return a reference to this, so the API can be used fluently
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   Tuple addLocalDateTime(LocalDateTime value);
 
   /**
@@ -751,7 +743,7 @@ public interface Tuple {
    * @param value the value
    * @return a reference to this, so the API can be used fluently
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   Tuple addOffsetTime(OffsetTime value);
 
   /**
@@ -760,7 +752,7 @@ public interface Tuple {
    * @param value the value
    * @return a reference to this, so the API can be used fluently
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   Tuple addOffsetDateTime(OffsetDateTime value);
 
   /**
@@ -769,7 +761,7 @@ public interface Tuple {
    * @param value the value
    * @return a reference to this, so the API can be used fluently
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   Tuple addUUID(UUID value);
 
   /**
@@ -778,7 +770,7 @@ public interface Tuple {
    * @param value the value
    * @return a reference to this, so the API can be used fluently
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   Tuple addNumeric(Numeric value);
 
   /**
@@ -787,7 +779,7 @@ public interface Tuple {
    * @param value the value
    * @return a reference to this, so the API can be used fluently
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   Tuple addBigDecimal(BigDecimal value);
 
   /**
@@ -796,7 +788,7 @@ public interface Tuple {
    * @param value the value
    * @return a reference to this, so the API can be used fluently
    */
-  @GenIgnore
+  @Fluent
   Tuple addPoint(Point value);
 
   /**
@@ -805,7 +797,7 @@ public interface Tuple {
    * @param value the value
    * @return a reference to this, so the API can be used fluently
    */
-  @GenIgnore
+  @Fluent
   Tuple addLine(Line value);
 
   /**
@@ -814,7 +806,7 @@ public interface Tuple {
    * @param value the value
    * @return a reference to this, so the API can be used fluently
    */
-  @GenIgnore
+  @Fluent
   Tuple addLineSegment(LineSegment value);
 
   /**
@@ -823,7 +815,7 @@ public interface Tuple {
    * @param value the value
    * @return a reference to this, so the API can be used fluently
    */
-  @GenIgnore
+  @Fluent
   Tuple addBox(Box value);
 
   /**
@@ -832,7 +824,7 @@ public interface Tuple {
    * @param value the value
    * @return a reference to this, so the API can be used fluently
    */
-  @GenIgnore
+  @Fluent
   Tuple addPath(Path value);
 
   /**
@@ -841,7 +833,7 @@ public interface Tuple {
    * @param value the value
    * @return a reference to this, so the API can be used fluently
    */
-  @GenIgnore
+  @Fluent
   Tuple addPolygon(Polygon value);
 
   /**
@@ -850,7 +842,7 @@ public interface Tuple {
    * @param value the value
    * @return a reference to this, so the API can be used fluently
    */
-  @GenIgnore
+  @Fluent
   Tuple addCircle(Circle value);
 
   /**
@@ -859,7 +851,7 @@ public interface Tuple {
    * @param value the value
    * @return a reference to this, so the API can be used fluently
    */
-  @GenIgnore
+  @Fluent
   Tuple addInterval(Interval value);
 
   /**
@@ -868,7 +860,7 @@ public interface Tuple {
    * @param value the value
    * @return a reference to this, so the API can be used fluently
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   Tuple addIntegerArray(Integer[] value);
 
   /**
@@ -877,7 +869,7 @@ public interface Tuple {
    * @param value the value
    * @return a reference to this, so the API can be used fluently
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   Tuple addBooleanArray(Boolean[] value);
 
   /**
@@ -886,7 +878,7 @@ public interface Tuple {
    * @param value the value
    * @return a reference to this, so the API can be used fluently
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   Tuple addShortArray(Short[] value);
 
   /**
@@ -895,7 +887,7 @@ public interface Tuple {
    * @param value the value
    * @return a reference to this, so the API can be used fluently
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   Tuple addLongArray(Long[] value);
 
   /**
@@ -904,7 +896,7 @@ public interface Tuple {
    * @param value the value
    * @return a reference to this, so the API can be used fluently
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   Tuple addFloatArray(Float[] value);
 
   /**
@@ -913,7 +905,7 @@ public interface Tuple {
    * @param value the value
    * @return a reference to this, so the API can be used fluently
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   Tuple addDoubleArray(Double[] value);
 
   /**
@@ -922,7 +914,7 @@ public interface Tuple {
    * @param value the value
    * @return a reference to this, so the API can be used fluently
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   Tuple addStringArray(String[] value);
 
   /**
@@ -931,7 +923,7 @@ public interface Tuple {
    * @param value the value
    * @return a reference to this, so the API can be used fluently
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   Tuple addLocalDateArray(LocalDate[] value);
 
   /**
@@ -940,7 +932,7 @@ public interface Tuple {
    * @param value the value
    * @return a reference to this, so the API can be used fluently
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   Tuple addLocalTimeArray(LocalTime[] value);
 
   /**
@@ -949,7 +941,7 @@ public interface Tuple {
    * @param value the value
    * @return a reference to this, so the API can be used fluently
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   Tuple addOffsetTimeArray(OffsetTime[] value);
 
   /**
@@ -958,7 +950,7 @@ public interface Tuple {
    * @param value the value
    * @return a reference to this, so the API can be used fluently
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   Tuple addLocalDateTimeArray(LocalDateTime[] value);
 
   /**
@@ -967,7 +959,7 @@ public interface Tuple {
    * @param value the value
    * @return a reference to this, so the API can be used fluently
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   Tuple addOffsetDateTimeArray(OffsetDateTime[] value);
 
   /**
@@ -985,7 +977,7 @@ public interface Tuple {
    * @param value the value
    * @return a reference to this, so the API can be used fluently
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   Tuple addUUIDArray(UUID[] value);
 
   /**
@@ -1003,7 +995,7 @@ public interface Tuple {
    * @param value the value
    * @return a reference to this, so the API can be used fluently
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   Tuple addNumericArray(Numeric[] value);
 
   /**
@@ -1012,7 +1004,7 @@ public interface Tuple {
    * @param value the value
    * @return a reference to this, so the API can be used fluently
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   Tuple addPointArray(Point[] value);
 
   /**
@@ -1021,7 +1013,7 @@ public interface Tuple {
    * @param value the value
    * @return a reference to this, so the API can be used fluently
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   Tuple addLineArray(Line[] value);
 
   /**
@@ -1030,7 +1022,7 @@ public interface Tuple {
    * @param value the value
    * @return a reference to this, so the API can be used fluently
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   Tuple addLineSegmentArray(LineSegment[] value);
 
   /**
@@ -1039,7 +1031,7 @@ public interface Tuple {
    * @param value the value
    * @return a reference to this, so the API can be used fluently
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   Tuple addBoxArray(Box[] value);
 
   /**
@@ -1048,7 +1040,7 @@ public interface Tuple {
    * @param value the value
    * @return a reference to this, so the API can be used fluently
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   Tuple addPathArray(Path[] value);
 
   /**
@@ -1057,7 +1049,7 @@ public interface Tuple {
    * @param value the value
    * @return a reference to this, so the API can be used fluently
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   Tuple addPolygonArray(Polygon[] value);
 
   /**
@@ -1066,7 +1058,7 @@ public interface Tuple {
    * @param value the value
    * @return a reference to this, so the API can be used fluently
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   Tuple addCircleArray(Circle[] value);
 
   /**
@@ -1075,7 +1067,7 @@ public interface Tuple {
    * @param value the value
    * @return a reference to this, so the API can be used fluently
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   Tuple addIntervalArray(Interval[] value);
 
   /**

--- a/src/main/java/io/reactiverse/pgclient/data/Interval.java
+++ b/src/main/java/io/reactiverse/pgclient/data/Interval.java
@@ -195,9 +195,26 @@ public class Interval {
   }
 
   @Override
+  public int hashCode() {
+    int result = years;
+    result = 31 * result + months;
+    result = 31 * result + days;
+    result = 31 * result + hours;
+    result = 31 * result + minutes;
+    result = 31 * result + seconds;
+    result = 31 * result + microseconds;
+    return result;
+  }
+
+  @Override
   public String toString() {
     return "Interval( " + years + " years " + months + " months " + days + " days " + hours + " hours " +
       minutes + " minutes " + seconds + (microseconds == 0 ? "" : "." + Math.abs(microseconds)) + " seconds )";
   }
 
+  public JsonObject toJson() {
+    JsonObject json = new JsonObject();
+    IntervalConverter.toJson(this, json);
+    return json;
+  }
 }


### PR DESCRIPTION
…sible

Changes:
1. Drop `@GenIgnore` of geometric types and `Interval`
2. Use `@GenIgnore(GenIgnore.PERMITTED_TYPE)` in java type or java/data object array type when possible so that it can be generated in rxi-fied API.